### PR TITLE
extend combine shape type

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -1341,6 +1341,17 @@ export function attach<
   name?: string
 }): Effect<Parameters<FN>[0] , EffectResult<FX>, EffectError<FX>>
 
+type UnionToStoresUnion<T> = (T extends any
+  ? () => T
+  : never) extends infer U
+  ? U extends () => infer S
+    ? UnionToStoresUnion<Exclude<T, S>> | Store<S>
+    : never
+  : never
+type CombineState<State> = {
+  [K in keyof State]: State[K] | Store<State[K]> | UnionToStoresUnion<State[K]>
+}
+
 export function withRegion(unit: Unit<any> | Node, cb: () => void): void
 export function combine<T extends Store<any>>(
   store: T,
@@ -1349,7 +1360,7 @@ export function combine<State extends Tuple>(
   shape: State,
 ): Store<{[K in keyof State]: State[K] extends Store<infer U> ? U : State[K]}>
 export function combine<State>(
-  shape: State,
+  shape: CombineState<State>,
 ): Store<{[K in keyof State]: State[K] extends Store<infer U> ? U : State[K]}>
 export function combine<A, R>(a: Store<A>, fn: (a: A) => R): Store<R>
 export function combine<State extends Tuple, R>(


### PR DESCRIPTION
If type of shape is passed explicitly to `combine`, it's impossible to use Stores in it, because of TS error:
![image](https://user-images.githubusercontent.com/38786565/110843139-076bd480-82b9-11eb-97e4-2bdb584b6fe6.png)

This extension makes this behavior possible: 
![image](https://user-images.githubusercontent.com/38786565/110843586-852fe000-82b9-11eb-8a34-ba1b5b570865.png)