### PR TITLE
prevent infinite recursion in `UnionToStoresUnion` type

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -1344,15 +1344,17 @@ export function attach<
 type UnionToStoresUnion<T> = (T extends never
   ? never
   : () => T) extends infer U
-  ? U extends () => infer S
-    ? UnionToStoresUnion<Exclude<T, S>> | Store<S>
+    ? U extends () => infer S
+      ? UnionToStoresUnion<Exclude<T, S>> | Store<S>
+      : never
     : never
-  : never
 type CombineState<State> = {
   [K in keyof State]:
-  | State[K]
-  | Store<Exclude<State[K], undefined>>
-  | UnionToStoresUnion<Exclude<State[K], undefined>>
+    | State[K]
+    | (undefined extends State[K]
+      ? Store<Exclude<State[K], undefined>>
+      : Store<State[K]>)
+    | UnionToStoresUnion<Exclude<State[K], undefined>>
 }
 
 export function withRegion(unit: Unit<any> | Node, cb: () => void): void

--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -1341,9 +1341,9 @@ export function attach<
   name?: string
 }): Effect<Parameters<FN>[0] , EffectResult<FX>, EffectError<FX>>
 
-type UnionToStoresUnion<T> = (T extends any
-  ? () => T
-  : never) extends infer U
+type UnionToStoresUnion<T> = (T extends never
+  ? never
+  : () => T) extends infer U
   ? U extends () => infer S
     ? UnionToStoresUnion<Exclude<T, S>> | Store<S>
     : never

--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -1349,7 +1349,10 @@ type UnionToStoresUnion<T> = (T extends never
     : never
   : never
 type CombineState<State> = {
-  [K in keyof State]: State[K] | Store<State[K]> | UnionToStoresUnion<State[K]>
+  [K in keyof State]:
+  | State[K]
+  | Store<Exclude<State[K], undefined>>
+  | UnionToStoresUnion<Exclude<State[K], undefined>>
 }
 
 export function withRegion(unit: Unit<any> | Node, cb: () => void): void


### PR DESCRIPTION
Fix for #463 

Current type has leak for infinite recursion because of `T extends any` condition - it's always true. But TS still handles this type without any issues, that's why I didn't notice the leak.

New condition has safe guard from infinite recursion and it works the same. 