### PR TITLE
Event type fix

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -120,14 +120,16 @@ export type CompositeName = {
 type EventAsReturnType<Payload> = any extends Payload ? Event<Payload> : never
 
 export interface Event<Payload> extends Unit<Payload> {
-  (payload: Payload): Payload
-  (this: Payload extends void ? void : `Error: Expected 1 argument, but got 0`, payload?: Payload): void
+  <T extends Payload>(payload: Payload): T
+  <T extends Payload>(this: Payload extends void ? void : `Error: Expected 1 argument, but got 0`, payload?: T): void
   watch(watcher: (payload: Payload) => any): Subscription
   map<T>(fn: (payload: Payload) => T): EventAsReturnType<T>
   filter<T extends Payload>(config: {
     fn(payload: Payload): payload is T
   }): EventAsReturnType<T>
-  filter(config: {fn(payload: Payload): boolean}): EventAsReturnType<Payload>
+  filter<T extends Payload>(config: {
+    fn(payload: Payload): boolean
+  }): EventAsReturnType<T>
   filterMap<T>(fn: (payload: Payload) => T | undefined): EventAsReturnType<T>
   prepend<Before = void>(fn: (_: Before) => Payload): Event<Before>
   subscribe(observer: Observer<Payload>): Subscription

--- a/src/types/__tests__/effector/attach.test.ts
+++ b/src/types/__tests__/effector/attach.test.ts
@@ -115,11 +115,11 @@ describe('params type mismatch', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       Type 'Effect<number, string, { message: string; }>' is not assignable to type 'Effect<string, string, { message: string; }>'.
-        The types of 'done.watch' are incompatible between these types.
-          Type '(watcher: (payload: { params: number; result: string; }) => any) => Subscription' is not assignable to type '(watcher: (payload: { params: string; result: string; }) => any) => Subscription'.
-            Types of parameters 'watcher' and 'watcher' are incompatible.
-              Types of parameters 'payload' and 'payload' are incompatible.
-                Type '{ params: number; result: string; }' is not assignable to type '{ params: string; result: string; }'.
+        Types of property 'done' are incompatible.
+          Type 'Event<{ params: number; result: string; }>' is not assignable to type 'Event<{ params: string; result: string; }>'.
+            Type '{ params: number; result: string; }' is not assignable to type '{ params: string; result: string; }'.
+              Types of property 'params' are incompatible.
+                Type 'number' is not assignable to type 'string'.
       No overload matches this call.
         The last overload gave the following error.
           Type '(text: number) => { foo: number; }' is not assignable to type '(params: any, source: any) => { foo: string; }'.

--- a/src/types/__tests__/effector/combine.test.ts
+++ b/src/types/__tests__/effector/combine.test.ts
@@ -186,8 +186,9 @@ describe('error inference (should fail with number -> string error)', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       Type 'Store<{ R: number; G: number; B: number; }>' is not assignable to type 'Store<{ R: string; G: string; B: string; }>'.
-        The types returned by 'getState()' are incompatible between these types.
-          Type '{ R: number; G: number; B: number; }' is not assignable to type '{ R: string; G: string; B: string; }'.
+        Type '{ R: number; G: number; B: number; }' is not assignable to type '{ R: string; G: string; B: string; }'.
+          Types of property 'R' are incompatible.
+            Type 'number' is not assignable to type 'string'.
       "
     `)
   })
@@ -200,8 +201,8 @@ describe('error inference (should fail with number -> string error)', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       Type 'Store<[number, number, number]>' is not assignable to type 'Store<[string, string, string]>'.
-        The types returned by 'getState()' are incompatible between these types.
-          Type '[number, number, number]' is not assignable to type '[string, string, string]'.
+        Type '[number, number, number]' is not assignable to type '[string, string, string]'.
+          Type 'number' is not assignable to type 'string'.
       "
     `)
   })
@@ -212,8 +213,9 @@ describe('error inference (should fail with number -> string error)', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       Type 'Store<{ Color: string; }>' is not assignable to type 'Store<{ Color: number; }>'.
-        The types returned by 'getState()' are incompatible between these types.
-          Type '{ Color: string; }' is not assignable to type '{ Color: number; }'.
+        Type '{ Color: string; }' is not assignable to type '{ Color: number; }'.
+          Types of property 'Color' are incompatible.
+            Type 'string' is not assignable to type 'number'.
       "
     `)
   })
@@ -224,8 +226,8 @@ describe('error inference (should fail with number -> string error)', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       Type 'Store<[string]>' is not assignable to type 'Store<[number]>'.
-        The types returned by 'getState()' are incompatible between these types.
-          Type '[string]' is not assignable to type '[number]'.
+        Type '[string]' is not assignable to type '[number]'.
+          Type 'string' is not assignable to type 'number'.
       "
     `)
   })
@@ -245,8 +247,7 @@ describe('error inference (should fail with number -> string error)', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       Type 'Store<string>' is not assignable to type 'Store<number>'.
-        The types returned by 'getState()' are incompatible between these types.
-          Type 'string' is not assignable to type 'number'.
+        Type 'string' is not assignable to type 'number'.
       "
     `)
   })
@@ -339,8 +340,7 @@ describe('error inference (should fail with number -> string error)', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       Type 'Store<[string]>' is not assignable to type 'Store<number>'.
-        The types returned by 'getState()' are incompatible between these types.
-          Type '[string]' is not assignable to type 'number'.
+        Type '[string]' is not assignable to type 'number'.
       "
     `)
   })

--- a/src/types/__tests__/effector/createApi.test.ts
+++ b/src/types/__tests__/effector/createApi.test.ts
@@ -25,11 +25,7 @@ test('check2', () => {
   expect(typecheck).toMatchInlineSnapshot(`
     "
     Type 'Event<number>' is not assignable to type 'Event<string>'.
-      Types of property 'watch' are incompatible.
-        Type '(watcher: (payload: number) => any) => Subscription' is not assignable to type '(watcher: (payload: string) => any) => Subscription'.
-          Types of parameters 'watcher' and 'watcher' are incompatible.
-            Types of parameters 'payload' and 'payload' are incompatible.
-              Type 'number' is not assignable to type 'string'.
+      Type 'number' is not assignable to type 'string'.
     "
   `)
 })
@@ -43,11 +39,7 @@ test('check3', () => {
   expect(typecheck).toMatchInlineSnapshot(`
     "
     Type 'Event<void>' is not assignable to type 'Event<string>'.
-      Types of property 'watch' are incompatible.
-        Type '(watcher: (payload: void) => any) => Subscription' is not assignable to type '(watcher: (payload: string) => any) => Subscription'.
-          Types of parameters 'watcher' and 'watcher' are incompatible.
-            Types of parameters 'payload' and 'payload' are incompatible.
-              Type 'void' is not assignable to type 'string'.
+      Type 'void' is not assignable to type 'string'.
     "
   `)
 })

--- a/src/types/__tests__/effector/effect.test.ts
+++ b/src/types/__tests__/effector/effect.test.ts
@@ -271,11 +271,7 @@ describe('#filter', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       Type 'Event<number>' is not assignable to type 'Event<boolean>'.
-        Types of property 'watch' are incompatible.
-          Type '(watcher: (payload: number) => any) => Subscription' is not assignable to type '(watcher: (payload: boolean) => any) => Subscription'.
-            Types of parameters 'watcher' and 'watcher' are incompatible.
-              Types of parameters 'payload' and 'payload' are incompatible.
-                Type 'number' is not assignable to type 'boolean'.
+        Type 'number' is not assignable to type 'boolean'.
       "
     `)
   })
@@ -312,10 +308,7 @@ describe('#filterMap', () => {
 
     expect(typecheck).toMatchInlineSnapshot(`
       "
-      Type 'Event<number>' is not assignable to type 'Event<number | void>'.
-        Types of parameters 'payload' and 'payload' are incompatible.
-          Type 'number | void' is not assignable to type 'number'.
-            Type 'void' is not assignable to type 'number'.
+      no errors
       "
     `)
   })
@@ -477,11 +470,11 @@ describe('nested effects', () => {
       expect(typecheck).toMatchInlineSnapshot(`
         "
         Type 'Effect<string, string, Error>' is not assignable to type 'Effect<number, number, Error>'.
-          The types of 'done.watch' are incompatible between these types.
-            Type '(watcher: (payload: { params: string; result: string; }) => any) => Subscription' is not assignable to type '(watcher: (payload: { params: number; result: number; }) => any) => Subscription'.
-              Types of parameters 'watcher' and 'watcher' are incompatible.
-                Types of parameters 'payload' and 'payload' are incompatible.
-                  Type '{ params: string; result: string; }' is not assignable to type '{ params: number; result: number; }'.
+          Types of property 'done' are incompatible.
+            Type 'Event<{ params: string; result: string; }>' is not assignable to type 'Event<{ params: number; result: number; }>'.
+              Type '{ params: string; result: string; }' is not assignable to type '{ params: number; result: number; }'.
+                Types of property 'params' are incompatible.
+                  Type 'string' is not assignable to type 'number'.
         "
       `)
     })

--- a/src/types/__tests__/effector/event.test.ts
+++ b/src/types/__tests__/effector/event.test.ts
@@ -48,11 +48,7 @@ test('#map', () => {
   expect(typecheck).toMatchInlineSnapshot(`
     "
     Type 'Event<string>' is not assignable to type 'Event<number>'.
-      Types of property 'watch' are incompatible.
-        Type '(watcher: (payload: string) => any) => Subscription' is not assignable to type '(watcher: (payload: number) => any) => Subscription'.
-          Types of parameters 'watcher' and 'watcher' are incompatible.
-            Types of parameters 'payload' and 'payload' are incompatible.
-              Type 'string' is not assignable to type 'number'.
+      Type 'string' is not assignable to type 'number'.
     "
   `)
 })
@@ -249,9 +245,7 @@ test('assign event to a function (should fail)', () => {
   const fn1: (event: number) => unknown = createEvent<string>()
   expect(typecheck).toMatchInlineSnapshot(`
     "
-    Type 'Event<string>' is not assignable to type '(event: number) => unknown'.
-      Types of parameters 'payload' and 'event' are incompatible.
-        Type 'number' is not assignable to type 'string'.
+    no errors
     "
   `)
 })
@@ -276,6 +270,7 @@ describe('event as function argument', () => {
     fn(e => event(e))
     expect(typecheck).toMatchInlineSnapshot(`
       "
+      Type 'string' is not assignable to type 'number'.
       No overload matches this call.
         Overload 1 of 2, '(payload: string): string', gave the following error.
           Argument of type 'number' is not assignable to parameter of type 'string'.
@@ -290,7 +285,9 @@ test('createEvent edge case', () => {
   const fn: (event: number) => number = createEvent()
   expect(typecheck).toMatchInlineSnapshot(`
     "
-    no errors
+    Type 'Event<void>' is not assignable to type '(event: number) => number'.
+      Types of parameters 'payload' and 'event' are incompatible.
+        Type 'number' is not assignable to type 'void'.
     "
   `)
 })

--- a/src/types/__tests__/effector/guard.test.ts
+++ b/src/types/__tests__/effector/guard.test.ts
@@ -178,8 +178,7 @@ describe('guard(source, config)', () => {
           The last overload gave the following error.
             Type 'Store<string>' is not assignable to type 'Store<boolean> | ((source: number) => boolean)'.
               Type 'Store<string>' is not assignable to type 'Store<boolean>'.
-                The types returned by 'getState()' are incompatible between these types.
-                  Type 'string' is not assignable to type 'boolean'.
+                Type 'string' is not assignable to type 'boolean'.
         "
       `)
     })
@@ -315,11 +314,7 @@ describe('guard(source, config)', () => {
       expect(typecheck).toMatchInlineSnapshot(`
         "
         Type 'Event<User>' is not assignable to type 'Event<string>'.
-          Types of property 'watch' are incompatible.
-            Type '(watcher: (payload: User) => any) => Subscription' is not assignable to type '(watcher: (payload: string) => any) => Subscription'.
-              Types of parameters 'watcher' and 'watcher' are incompatible.
-                Types of parameters 'payload' and 'payload' are incompatible.
-                  Type 'User' is not assignable to type 'string'.
+          Type 'User' is not assignable to type 'string'.
         "
       `)
     })
@@ -596,11 +591,7 @@ describe('guard(config)', () => {
       expect(typecheck).toMatchInlineSnapshot(`
         "
         Type 'Event<User>' is not assignable to type 'Event<string>'.
-          Types of property 'watch' are incompatible.
-            Type '(watcher: (payload: User) => any) => Subscription' is not assignable to type '(watcher: (payload: string) => any) => Subscription'.
-              Types of parameters 'watcher' and 'watcher' are incompatible.
-                Types of parameters 'payload' and 'payload' are incompatible.
-                  Type 'User' is not assignable to type 'string'.
+          Type 'User' is not assignable to type 'string'.
         "
       `)
     })

--- a/src/types/__tests__/effector/guard/guardWideNarrow.test.ts
+++ b/src/types/__tests__/effector/guard/guardWideNarrow.test.ts
@@ -39,11 +39,11 @@ test('wide union (should fail)', () => {
       The last overload gave the following error.
         Type 'Event<{ a: 1; } | { a: 2; }>' is not assignable to type '\\"incompatible unit in target\\"'.
     Type 'Event<{ a: 1; } | { a: 2; } | { a: 3; }>' is not assignable to type 'Event<{ a: 1; } | { a: 2; }>'.
-      Types of property 'watch' are incompatible.
-        Type '(watcher: (payload: { a: 1; } | { a: 2; } | { a: 3; }) => any) => Subscription' is not assignable to type '(watcher: (payload: { a: 1; } | { a: 2; }) => any) => Subscription'.
-          Types of parameters 'watcher' and 'watcher' are incompatible.
-            Types of parameters 'payload' and 'payload' are incompatible.
-              Type '{ a: 1; } | { a: 2; } | { a: 3; }' is not assignable to type '{ a: 1; } | { a: 2; }'.
+      Type '{ a: 1; } | { a: 2; } | { a: 3; }' is not assignable to type '{ a: 1; } | { a: 2; }'.
+        Type '{ a: 3; }' is not assignable to type '{ a: 1; } | { a: 2; }'.
+          Type '{ a: 3; }' is not assignable to type '{ a: 2; }'.
+            Types of property 'a' are incompatible.
+              Type '3' is not assignable to type '2'.
     No overload matches this call.
       The last overload gave the following error.
         Type 'Event<{ a: 1; } | { a: 2; }>' is not assignable to type '\\"incompatible unit in target\\"'.
@@ -113,11 +113,7 @@ test('unknown type in source (should fail)', () => {
       The last overload gave the following error.
         Type 'Event<string>' is not assignable to type '\\"incompatible unit in target\\"'.
     Type 'Event<unknown>' is not assignable to type 'Event<string>'.
-      Types of property 'watch' are incompatible.
-        Type '(watcher: (payload: unknown) => any) => Subscription' is not assignable to type '(watcher: (payload: string) => any) => Subscription'.
-          Types of parameters 'watcher' and 'watcher' are incompatible.
-            Types of parameters 'payload' and 'payload' are incompatible.
-              Type 'unknown' is not assignable to type 'string'.
+      Type 'unknown' is not assignable to type 'string'.
     No overload matches this call.
       The last overload gave the following error.
         Type 'Event<string>' is not assignable to type '\\"incompatible unit in target\\"'.
@@ -187,11 +183,10 @@ test('optional props (should fail)', () => {
       The last overload gave the following error.
         Type 'Event<{ a: 1; b: 2; }>' is not assignable to type '\\"incompatible unit in target\\"'.
     Type 'Event<{ a: 1; b?: 2 | undefined; }>' is not assignable to type 'Event<{ a: 1; b: 2; }>'.
-      Types of property 'watch' are incompatible.
-        Type '(watcher: (payload: { a: 1; b?: 2 | undefined; }) => any) => Subscription' is not assignable to type '(watcher: (payload: { a: 1; b: 2; }) => any) => Subscription'.
-          Types of parameters 'watcher' and 'watcher' are incompatible.
-            Types of parameters 'payload' and 'payload' are incompatible.
-              Type '{ a: 1; b?: 2 | undefined; }' is not assignable to type '{ a: 1; b: 2; }'.
+      Type '{ a: 1; b?: 2 | undefined; }' is not assignable to type '{ a: 1; b: 2; }'.
+        Types of property 'b' are incompatible.
+          Type '2 | undefined' is not assignable to type '2'.
+            Type 'undefined' is not assignable to type '2'.
     No overload matches this call.
       The last overload gave the following error.
         Type 'Event<{ a: 1; b: 2; }>' is not assignable to type '\\"incompatible unit in target\\"'.
@@ -261,11 +256,7 @@ test('narrow object (should fail)', () => {
       The last overload gave the following error.
         Type 'Event<{ a: 1; b: 2; c: 3; }>' is not assignable to type '\\"incompatible unit in target\\"'.
     Type 'Event<{ a: 1; b: 2; }>' is not assignable to type 'Event<{ a: 1; b: 2; c: 3; }>'.
-      Types of property 'watch' are incompatible.
-        Type '(watcher: (payload: { a: 1; b: 2; }) => any) => Subscription' is not assignable to type '(watcher: (payload: { a: 1; b: 2; c: 3; }) => any) => Subscription'.
-          Types of parameters 'watcher' and 'watcher' are incompatible.
-            Types of parameters 'payload' and 'payload' are incompatible.
-              Type '{ a: 1; b: 2; }' is not assignable to type '{ a: 1; b: 2; c: 3; }'.
+      Property 'c' is missing in type '{ a: 1; b: 2; }' but required in type '{ a: 1; b: 2; c: 3; }'.
     No overload matches this call.
       The last overload gave the following error.
         Type 'Event<{ a: 1; b: 2; c: 3; }>' is not assignable to type '\\"incompatible unit in target\\"'.
@@ -386,11 +377,9 @@ test('wide union in array (should fail)', () => {
       The last overload gave the following error.
         Type 'Event<(string | number)[]>' is not assignable to type '\\"incompatible unit in target\\"'.
     Type 'Event<(string | number | boolean)[]>' is not assignable to type 'Event<(string | number)[]>'.
-      Types of property 'watch' are incompatible.
-        Type '(watcher: (payload: (string | number | boolean)[]) => any) => Subscription' is not assignable to type '(watcher: (payload: (string | number)[]) => any) => Subscription'.
-          Types of parameters 'watcher' and 'watcher' are incompatible.
-            Types of parameters 'payload' and 'payload' are incompatible.
-              Type '(string | number | boolean)[]' is not assignable to type '(string | number)[]'.
+      Type '(string | number | boolean)[]' is not assignable to type '(string | number)[]'.
+        Type 'string | number | boolean' is not assignable to type 'string | number'.
+          Type 'boolean' is not assignable to type 'string | number'.
     No overload matches this call.
       The last overload gave the following error.
         Type 'Event<(string | number)[]>' is not assignable to type '\\"incompatible unit in target\\"'.

--- a/src/types/__tests__/effector/index.test.ts
+++ b/src/types/__tests__/effector/index.test.ts
@@ -66,11 +66,7 @@ describe('split', () => {
         expect(typecheck).toMatchInlineSnapshot(`
           "
           Type 'Event<string[]>' is not assignable to type 'Event<number>'.
-            Types of property 'watch' are incompatible.
-              Type '(watcher: (payload: string[]) => any) => Subscription' is not assignable to type '(watcher: (payload: number) => any) => Subscription'.
-                Types of parameters 'watcher' and 'watcher' are incompatible.
-                  Types of parameters 'payload' and 'payload' are incompatible.
-                    Type 'string[]' is not assignable to type 'number'.
+            Type 'string[]' is not assignable to type 'number'.
           Type 'Event<string[]>' is not assignable to type 'null'.
           "
         `)

--- a/src/types/__tests__/effector/sample/sample.test.ts
+++ b/src/types/__tests__/effector/sample/sample.test.ts
@@ -168,11 +168,7 @@ test('event by event with handler', () => {
   expect(typecheck).toMatchInlineSnapshot(`
     "
     Type 'Event<{ a: string; b: boolean; }>' is not assignable to type 'Event<string>'.
-      Types of property 'watch' are incompatible.
-        Type '(watcher: (payload: { a: string; b: boolean; }) => any) => Subscription' is not assignable to type '(watcher: (payload: string) => any) => Subscription'.
-          Types of parameters 'watcher' and 'watcher' are incompatible.
-            Types of parameters 'payload' and 'payload' are incompatible.
-              Type '{ a: string; b: boolean; }' is not assignable to type 'string'.
+      Type '{ a: string; b: boolean; }' is not assignable to type 'string'.
     "
   `)
 })
@@ -202,11 +198,7 @@ test('store by event with handler', () => {
   expect(typecheck).toMatchInlineSnapshot(`
     "
     Type 'Event<{ a: string; b: boolean; }>' is not assignable to type 'Event<string>'.
-      Types of property 'watch' are incompatible.
-        Type '(watcher: (payload: { a: string; b: boolean; }) => any) => Subscription' is not assignable to type '(watcher: (payload: string) => any) => Subscription'.
-          Types of parameters 'watcher' and 'watcher' are incompatible.
-            Types of parameters 'payload' and 'payload' are incompatible.
-              Type '{ a: string; b: boolean; }' is not assignable to type 'string'.
+      Type '{ a: string; b: boolean; }' is not assignable to type 'string'.
     "
   `)
 })
@@ -236,11 +228,7 @@ test('effect by event with handler', () => {
   expect(typecheck).toMatchInlineSnapshot(`
     "
     Type 'Event<{ a: string; b: boolean; }>' is not assignable to type 'Event<number>'.
-      Types of property 'watch' are incompatible.
-        Type '(watcher: (payload: { a: string; b: boolean; }) => any) => Subscription' is not assignable to type '(watcher: (payload: number) => any) => Subscription'.
-          Types of parameters 'watcher' and 'watcher' are incompatible.
-            Types of parameters 'payload' and 'payload' are incompatible.
-              Type '{ a: string; b: boolean; }' is not assignable to type 'number'.
+      Type '{ a: string; b: boolean; }' is not assignable to type 'number'.
     "
   `)
 })
@@ -256,8 +244,7 @@ test('store by store', () => {
   expect(typecheck).toMatchInlineSnapshot(`
     "
     Type 'Store<boolean>' is not assignable to type 'Store<string>'.
-      The types returned by 'getState()' are incompatible between these types.
-        Type 'boolean' is not assignable to type 'string'.
+      Type 'boolean' is not assignable to type 'string'.
     "
   `)
 })
@@ -272,8 +259,7 @@ test('store by store with handler', () => {
   expect(typecheck).toMatchInlineSnapshot(`
     "
     Type 'Store<{ a: string; b: boolean; }>' is not assignable to type 'Store<string>'.
-      The types returned by 'getState()' are incompatible between these types.
-        Type '{ a: string; b: boolean; }' is not assignable to type 'string'.
+      Type '{ a: string; b: boolean; }' is not assignable to type 'string'.
     "
   `)
 })

--- a/src/types/__tests__/effector/store.test.ts
+++ b/src/types/__tests__/effector/store.test.ts
@@ -284,3 +284,19 @@ test('#thru', () => {
     "
   `)
 })
+
+test('store edge case', () => {
+  type State = {
+    page: number
+    limit: number
+    [key: string]: any
+  }
+
+  const $values: Store<State> = createStore({page: 0, limit: 0, id: 1})
+
+  expect(typecheck).toMatchInlineSnapshot(`
+    "
+    no errors
+    "
+  `)
+})

--- a/src/types/__tests__/effector/store.test.ts
+++ b/src/types/__tests__/effector/store.test.ts
@@ -22,8 +22,7 @@ test('createStore', () => {
   expect(typecheck).toMatchInlineSnapshot(`
     "
     Type 'Store<number>' is not assignable to type 'Store<string>'.
-      The types returned by 'getState()' are incompatible between these types.
-        Type 'number' is not assignable to type 'string'.
+      Type 'number' is not assignable to type 'string'.
     "
   `)
 })


### PR DESCRIPTION
Here is a reproduction of the issue: [typescript playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgZRtApgGjgYyugQxnVQzgF84AzKCEOAcnSqvRzSgYCgv0APSLDgwAnmHRwAKgQBGAG3QAFAlAIgAznAC8iLnDhgCAc3QAuOADsAriBnooAbj1w5oYDHPXb9p5QBkcABKbNAAJgA86jBQwBZG2AQWIgB8Tlw4EBZRcAAkAG4Eclbomjp4hMSk+AAUCIYm5gAM2K4g7k3YMqoWoQCSoeYAjOQAlGkZWfDEUeZV6OHS8koqaurJ2rkFRSUOQA). 

I guess, we cannot assign one store type to another because the events in the `.updates` fields have call signatures... and Typescript is having [trouble](https://github.com/microsoft/TypeScript/issues/35162) working with them. TS checks if `TableParams` is assignable to object, but it should do the exact opposite.

I wrote a [test](https://github.com/effector/effector/compare/event-type-fix?expand=1#diff-73ebfc9702dc74a9c486d1a09493e552f3a60d6f91d37fa20c5dbe7bb8fbb87fR288-R294), and I think I found an interesting [solution](https://github.com/effector/effector/compare/event-type-fix?expand=1#diff-511df50df4b48edff6fd7944a6536f66766e4d3fa4d914c6cdb62149ae4a8965R122-R132).

There are some places to pay attention to: [1](https://github.com/effector/effector/pull/479/files#diff-1776bfbf8be28df8fd961369c42ea61c67e9cdb08ce3d77860ea0d8826f00fb2R311), [2](https://github.com/effector/effector/pull/479/files#diff-f0c3844cb20fa4863948134bef51f78e4414c188d1d1b1ca07d28cf838abda88R248) and [3](https://github.com/effector/effector/pull/479/files#diff-f0c3844cb20fa4863948134bef51f78e4414c188d1d1b1ca07d28cf838abda88L293):
1) `filterMap` returns a correct event type (needs to be updated)
2) Some sort of an edge case with `unknown`... it works as expected with `(event: number) => number`
3) No longer an issue (can be removed)