### PR TITLE
Fix docs index page horizontal scroll

### DIFF
--- a/website/client/src/pages/styles.module.css
+++ b/website/client/src/pages/styles.module.css
@@ -65,6 +65,7 @@ header[data-section-header] {
 
 .features > [data-features-grid] {
   grid-row: 2;
+  margin: 0;
 }
 
 .features [data-feature-image] {


### PR DESCRIPTION
Removed horizontal scrolling from the main page of the site from the "Features" block (Chrome 89, Firefox). There is probably a better way to solve the problem.

![image](https://user-images.githubusercontent.com/36932151/115998124-82c9e100-a5ee-11eb-9d5c-c37804311176.png)
