### PR TITLE
fix typo for `staff` on line 46

### DIFF
--- a/docs/api/effector-react/createComponent.md
+++ b/docs/api/effector-react/createComponent.md
@@ -43,7 +43,7 @@ const MyCounter = createComponent($counter, (props, state) => (
 ))
 
 const MyOwnComponent = () => {
-  // any staff here
+  // any stuff here
   return <MyCounter />
 }
 ```


### PR DESCRIPTION
Line 46 should read `// any stuff here` instead of `// any staff here`