### PR TITLE
Fix exports for react-native

### DIFF
--- a/packages/effector-react/package.json
+++ b/packages/effector-react/package.json
@@ -5,6 +5,7 @@
   "main": "effector-react.cjs.js",
   "module": "effector-react.mjs",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": "./effector-react.mjs",
       "require": "./effector-react.cjs.js",


### PR DESCRIPTION
**Describe the bug**
React native's metro bundler ignores `effector-react` and shows a warning.

Similar issues have been reported in many other projects as listed in [this react native cli issue](https://github.com/react-native-community/cli/issues/1168#issue-617427926) and [the fix used by those projects is quite simple and seemingly low risk](https://github.com/i18next/i18next-http-backend/commit/1d8da7909425eb33ab286cd73ee53bb48a1a3dc4#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R8).

**To Reproduce**
Steps to reproduce the behavior:

With node 16.13.0 and yarn 1.22.17 installed (as of this writing, the latest available in homebrew)...

1. Create a new react native app with `npx react-native init DummyProj`
2. `cd DummyProj/`
3. Install effector-react with `yarn add effector-react`
4. Start the metro bundler with `yarn start`
5. Observe the following error output:
```
> yarn start
yarn run v1.22.17
$ react-native start
warn Package effector-react has been ignored because it contains invalid configuration. Reason: Package subpath './package.json' is not defined by "exports" in /Users/a.mikhaylov/OwnProjects/DummyProj/node_modules/effector-react/package.json
```