### PR TITLE
Fix wide tuple (sample types)

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -1701,7 +1701,7 @@ type SampleFilterDef<
               : Clock extends Units
                 ? (clk: FNInfClock) => any
                 : any
-            ) 
+            )
             ? [(
                   Mode extends 'clock | source | filter | fn |       '
                 ? {clock: Clock; source: Source; filter?: FilterFun; fn?: FNInf; target?: never}
@@ -1800,11 +1800,14 @@ type TypeOfTargetSoft<SourceType, Target extends Units | ReadonlyArray<Unit<any>
         ? Target
         : WhichType<TargetType> extends ('void' | 'any')
           ? Target
-          : Mode extends 'fnRet'
-            ? never & {fnResult: SourceType; targetType: TargetType}
-            : Mode extends 'src'
-              ? never & {sourceType: SourceType; targetType: TargetType}
-              : {clockType: SourceType; targetType: TargetType}
+          : IfAssignable<SourceType, TargetType,
+            Target,
+            Mode extends 'fnRet'
+              ? never & {fnResult: SourceType; targetType: TargetType}
+              : Mode extends 'src'
+                ? never & {sourceType: SourceType; targetType: TargetType}
+                : {clockType: SourceType; targetType: TargetType}
+            >
       : never
     : {
       [
@@ -1814,11 +1817,14 @@ type TypeOfTargetSoft<SourceType, Target extends Units | ReadonlyArray<Unit<any>
           ? Target[K]
           : WhichType<TargetType> extends ('void' | 'any')
             ? Target[K]
-            : Mode extends 'fnRet'
-              ? never & {fnResult: SourceType; targetType: TargetType}
-              : Mode extends 'src'
-                ? never & {sourceType: SourceType; targetType: TargetType}
-                : {clockType: SourceType; targetType: TargetType}
+            : IfAssignable<SourceType, TargetType,
+              Target[K],
+              Mode extends 'fnRet'
+                ? never & {fnResult: SourceType; targetType: TargetType}
+                : Mode extends 'src'
+                  ? never & {sourceType: SourceType; targetType: TargetType}
+                  : {clockType: SourceType; targetType: TargetType}
+              >
         : never
     }
 

--- a/src/types/__tests__/effector/generated/sampleArrayTarget.test.ts
+++ b/src/types/__tests__/effector/generated/sampleArrayTarget.test.ts
@@ -1247,14 +1247,7 @@ const typecheck = '{global}'
       }
       expect(typecheck).toMatchInlineSnapshot(`
         "
-        Argument of type '{ source: (Store<number> | Store<string>)[]; target: Event<[number]>[]; }' is not assignable to parameter of type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }]; }'.
-          Object literal may only specify known properties, and 'source' does not exist in type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }]; }'.
-        Argument of type '{ source: (Store<number> | Store<string>)[]; target: (Event<[number]> | Event<[number, string]>)[]; }' is not assignable to parameter of type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }, Event<[number, string]>]; }'.
-          Object literal may only specify known properties, and 'source' does not exist in type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }, Event<[number, string]>]; }'.
-        Argument of type '{ source: (Store<number> | Store<string>)[]; clock: Event<number>; target: Event<[number]>[]; }' is not assignable to parameter of type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }]; }'.
-          Object literal may only specify known properties, and 'source' does not exist in type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }]; }'.
-        Argument of type '{ source: (Store<number> | Store<string>)[]; clock: Event<number>; target: (Event<[number]> | Event<[number, string]>)[]; }' is not assignable to parameter of type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }, Event<[number, string]>]; }'.
-          Object literal may only specify known properties, and 'source' does not exist in type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }, Event<[number, string]>]; }'.
+        no errors
         "
       `)
     })

--- a/src/types/__tests__/effector/sampleFilter/sampleFilterArrayTarget.test.ts
+++ b/src/types/__tests__/effector/sampleFilter/sampleFilterArrayTarget.test.ts
@@ -322,14 +322,7 @@ describe('combinable', () => {
       }
       expect(typecheck).toMatchInlineSnapshot(`
         "
-        Argument of type '{ filter: () => boolean; source: (Store<number> | Store<string>)[]; target: Event<[number]>[]; }' is not assignable to parameter of type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }]; }'.
-          Object literal may only specify known properties, and 'filter' does not exist in type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }]; }'.
-        Argument of type '{ filter: () => boolean; source: (Store<number> | Store<string>)[]; target: (Event<[number]> | Event<[number, string]>)[]; }' is not assignable to parameter of type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }, Event<[number, string]>]; }'.
-          Object literal may only specify known properties, and 'filter' does not exist in type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }, Event<[number, string]>]; }'.
-        Argument of type '{ filter: () => boolean; source: (Store<number> | Store<string>)[]; clock: Event<number>; target: Event<[number]>[]; }' is not assignable to parameter of type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }]; }'.
-          Object literal may only specify known properties, and 'filter' does not exist in type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }]; }'.
-        Argument of type '{ filter: () => boolean; source: (Store<number> | Store<string>)[]; clock: Event<number>; target: (Event<[number]> | Event<[number, string]>)[]; }' is not assignable to parameter of type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }, Event<[number, string]>]; }'.
-          Object literal may only specify known properties, and 'filter' does not exist in type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [number, string]; targetType: [number]; }, Event<[number, string]>]; }'.
+        no errors
         "
       `)
     })

--- a/src/types/__tests__/effector/sampleFilter/sampleFilterWideNarrow.test.ts
+++ b/src/types/__tests__/effector/sampleFilter/sampleFilterWideNarrow.test.ts
@@ -299,10 +299,7 @@ test('wide tuple (should pass)', () => {
 
   expect(typecheck).toMatchInlineSnapshot(`
     "
-    Argument of type '{ source: Event<[1, 2, 3]>; filter: Store<boolean>; target: Event<[1, 2]>; }' is not assignable to parameter of type '{ error: \\"source should extend target type\\"; targets: { sourceType: [1, 2, 3]; targetType: [1, 2]; }; }'.
-      Object literal may only specify known properties, and 'source' does not exist in type '{ error: \\"source should extend target type\\"; targets: { sourceType: [1, 2, 3]; targetType: [1, 2]; }; }'.
-    Argument of type '{ source: Event<[1, 2, 3]>; filter: Store<boolean>; target: Event<[1, 2]>[]; }' is not assignable to parameter of type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [1, 2, 3]; targetType: [1, 2]; }]; }'.
-      Object literal may only specify known properties, and 'source' does not exist in type '{ error: \\"source should extend target type\\"; targets: [{ sourceType: [1, 2, 3]; targetType: [1, 2]; }]; }'.
+    no errors
     "
   `)
 })


### PR DESCRIPTION
The wide tuple check is built into the `IfAssignable` helper:
```ts
      : T extends Array<any>
        ? number extends T['length']
          ? N
          : U extends Array<any>
            ? number extends U['length']
              ? N
              : TupleObject<T> extends TupleObject<U> ? Y : N
            : N
        : N
```
