### PR TITLE
Do not infer type from returned unit for sample

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -1483,8 +1483,8 @@ export function sample<
         ? SourceNoConf extends Store<any>
           ? Store<TypeOfSource<SourceNoConf>>
           : EventAsReturnType<TypeOfSource<SourceNoConf>>
-        : SampleRet<Target, Source, Clock, FLUnit, FLBool, FilterFun, FN, FNAltArg, FNInf, FNInfSource, FNInfClock, SomeFN, InferTarget>
-  : SampleRet<Target, Source, Clock, FLUnit, FLBool, FilterFun, FN, FNAltArg, FNInf, FNInfSource, FNInfClock, SomeFN, InferTarget>
+        : NoInfer<SampleRet<Target, Source, Clock, FLUnit, FLBool, FilterFun, FN, FNAltArg, FNInf, FNInfSource, FNInfClock, SomeFN, InferTarget>>
+  : NoInfer<SampleRet<Target, Source, Clock, FLUnit, FLBool, FilterFun, FN, FNAltArg, FNInf, FNInfSource, FNInfClock, SomeFN, InferTarget>>
 
 type ClTag = 'clock' | '     '
 type SrTag = 'source' | '      '

--- a/src/types/__tests__/effector/sample/clockArray.test.ts
+++ b/src/types/__tests__/effector/sample/clockArray.test.ts
@@ -365,9 +365,7 @@ describe('without target', () => {
     })
     expect(typecheck).toMatchInlineSnapshot(`
       "
-      Binding element 'a' implicitly has an 'any' type.
-      Binding element 'b' implicitly has an 'any' type.
-      Parameter 'clock' implicitly has an 'any' type.
+      no errors
       "
     `)
   })
@@ -397,9 +395,7 @@ describe('without target', () => {
 
     expect(typecheck).toMatchInlineSnapshot(`
       "
-      Binding element 'a' implicitly has an 'any' type.
-      Binding element 'b' implicitly has an 'any' type.
-      Parameter 'clock' implicitly has an 'any' type.
+      no errors
       "
     `)
   })


### PR DESCRIPTION
It's interesting that it became possible at all with this approach. We could use this feature for `prepend` (but we don't need it for sample)