### PR TITLE
Support store as `allSettled` argument

### DIFF
--- a/src/effector/__tests__/fork/allSettled.test.ts
+++ b/src/effector/__tests__/fork/allSettled.test.ts
@@ -7,6 +7,7 @@ import {
   allSettled,
   sample,
   serialize,
+  createStore,
 } from 'effector'
 
 test('allSettled first argument validation', async () => {
@@ -35,6 +36,12 @@ describe('allSettled return value', () => {
     const event = createEvent()
     const scope = fork()
     const result = await allSettled(event, {scope})
+    expect(result).toBe(undefined)
+  })
+  test('in case of store call', async () => {
+    const $store = createStore('value')
+    const scope = fork()
+    const result = await allSettled($store, {scope, params: 'value in scope'})
     expect(result).toBe(undefined)
   })
   describe('attach support', () => {
@@ -162,23 +169,33 @@ describe('transactions', () => {
     await promise2
     expect(serialize(scope1)).toMatchInlineSnapshot(`
       Object {
-        "w3iw57": Array [
+        "-20kfim": Array [
           "a",
         ],
-        "z6qtwf": "a",
+        "-ml3t19": "a",
       }
     `)
     expect(serialize(scope2)).toMatchInlineSnapshot(`
       Object {
-        "-44cjly": "b",
-        "qv6j32": Array [
+        "-20kfim": Array [
           "b",
         ],
-        "w3iw57": Array [
+        "-ml3t19": "b",
+        "-uwo3um": Array [
           "b",
         ],
-        "z6qtwf": "b",
+        "94wvfi": "b",
       }
     `)
+  })
+  test('starting store is serialized', async () => {
+    const $store = createStore('value')
+    const scope = fork()
+
+    await allSettled($store, {scope, params: 'value in scope'})
+    expect(serialize(scope)).toMatchObject({
+      [$store.sid as string]: "value in scope"
+    })
+    expect(scope.getState($store)).toEqual('value in scope')
   })
 })

--- a/src/effector/__tests__/fork/allSettled.test.ts
+++ b/src/effector/__tests__/fork/allSettled.test.ts
@@ -17,6 +17,31 @@ test('allSettled first argument validation', async () => {
   ).rejects.toThrowErrorMatchingInlineSnapshot(
     `"first argument should be unit"`,
   )
+
+  await expect(
+    allSettled(
+      createEffect(() => {}),
+      {scope: fork()},
+    ),
+  ).resolves.toEqual({status: 'done', value: undefined})
+
+  await expect(
+    allSettled(createEvent(), {scope: fork()}),
+  ).resolves.toBeUndefined()
+
+  await expect(
+    // @ts-expect-error
+    allSettled(createStore(0), {scope: fork()}),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `"first argument accepts only effects and events"`,
+  )
+
+  await expect(
+    // @ts-expect-error
+    allSettled(createDomain(), {scope: fork()}),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `"first argument accepts only effects and events"`,
+  )
 })
 
 describe('allSettled return value', () => {

--- a/src/effector/__tests__/fork/allSettled.test.ts
+++ b/src/effector/__tests__/fork/allSettled.test.ts
@@ -191,20 +191,20 @@ describe('transactions', () => {
     await promise2
     expect(serialize(scope1)).toMatchInlineSnapshot(`
       Object {
-        "-vdpqsm": Array [
+        "7ps077": "a",
+        "sabdpu": Array [
           "a",
         ],
-        "94wvds": "a",
       }
     `)
     expect(serialize(scope2)).toMatchInlineSnapshot(`
       Object {
-        "-k88fui": "b",
-        "-vdpqsm": Array [
+        "-lsam6": Array [
           "b",
         ],
-        "94wvds": "b",
-        "tckkf": Array [
+        "-vlbdb6": "b",
+        "7ps077": "b",
+        "sabdpu": Array [
           "b",
         ],
       }

--- a/src/effector/__tests__/fork/allSettled.test.ts
+++ b/src/effector/__tests__/fork/allSettled.test.ts
@@ -194,22 +194,22 @@ describe('transactions', () => {
     await promise2
     expect(serialize(scope1)).toMatchInlineSnapshot(`
       Object {
-        "-20kfim": Array [
+        "-vdpqsm": Array [
           "a",
         ],
-        "-ml3t19": "a",
+        "94wvds": "a",
       }
     `)
     expect(serialize(scope2)).toMatchInlineSnapshot(`
       Object {
-        "-20kfim": Array [
+        "-k88fui": "b",
+        "-vdpqsm": Array [
           "b",
         ],
-        "-ml3t19": "b",
-        "-uwo3um": Array [
+        "94wvds": "b",
+        "tckkf": Array [
           "b",
         ],
-        "94wvfi": "b",
       }
     `)
   })
@@ -219,7 +219,7 @@ describe('transactions', () => {
 
     await allSettled($store, {scope, params: 'value in scope'})
     expect(serialize(scope)).toMatchObject({
-      [$store.sid as string]: "value in scope"
+      [$store.sid as string]: 'value in scope',
     })
     expect(scope.getState($store)).toEqual('value in scope')
   })
@@ -227,15 +227,15 @@ describe('transactions', () => {
     const $store = createStore('value')
     sample({
       source: $store,
-      filter: str => !str.includes("1"),
-      fn: str => str + "1",
+      filter: str => !str.includes('1'),
+      fn: str => str + '1',
       target: $store,
     })
     const scope = fork()
 
     await allSettled($store, {scope, params: 'value in scope'})
     expect(serialize(scope)).toMatchObject({
-      [$store.sid as string]: "value in scope1"
+      [$store.sid as string]: 'value in scope1',
     })
     expect(scope.getState($store)).toEqual('value in scope1')
   })

--- a/src/effector/__tests__/fork/allSettled.test.ts
+++ b/src/effector/__tests__/fork/allSettled.test.ts
@@ -198,4 +198,20 @@ describe('transactions', () => {
     })
     expect(scope.getState($store)).toEqual('value in scope')
   })
+  test('starting store is serialized with correct value, if affected twice', async () => {
+    const $store = createStore('value')
+    sample({
+      source: $store,
+      filter: str => !str.includes("1"),
+      fn: str => str + "1",
+      target: $store,
+    })
+    const scope = fork()
+
+    await allSettled($store, {scope, params: 'value in scope'})
+    expect(serialize(scope)).toMatchObject({
+      [$store.sid as string]: "value in scope1"
+    })
+    expect(scope.getState($store)).toEqual('value in scope1')
+  })
 })

--- a/src/effector/__tests__/fork/allSettled.test.ts
+++ b/src/effector/__tests__/fork/allSettled.test.ts
@@ -7,7 +7,6 @@ import {
   allSettled,
   sample,
   serialize,
-  createStore,
 } from 'effector'
 
 test('allSettled first argument validation', async () => {
@@ -16,31 +15,6 @@ test('allSettled first argument validation', async () => {
     allSettled(null, {scope: fork()}),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
     `"first argument should be unit"`,
-  )
-
-  await expect(
-    allSettled(
-      createEffect(() => {}),
-      {scope: fork()},
-    ),
-  ).resolves.toEqual({status: 'done', value: undefined})
-
-  await expect(
-    allSettled(createEvent(), {scope: fork()}),
-  ).resolves.toBeUndefined()
-
-  await expect(
-    // @ts-expect-error
-    allSettled(createStore(0), {scope: fork()}),
-  ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"first argument accepts only effects and events"`,
-  )
-
-  await expect(
-    // @ts-expect-error
-    allSettled(createDomain(), {scope: fork()}),
-  ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"first argument accepts only effects and events"`,
   )
 })
 
@@ -188,22 +162,22 @@ describe('transactions', () => {
     await promise2
     expect(serialize(scope1)).toMatchInlineSnapshot(`
       Object {
-        "-3nax9h": "a",
-        "qv6ij9": Array [
+        "w3iw57": Array [
           "a",
         ],
+        "z6qtwf": "a",
       }
     `)
     expect(serialize(scope2)).toMatchInlineSnapshot(`
       Object {
-        "-20x5sr": Array [
+        "-44cjly": "b",
+        "qv6j32": Array [
           "b",
         ],
-        "-3nax9h": "b",
-        "-x0g8hr": "b",
-        "qv6ij9": Array [
+        "w3iw57": Array [
           "b",
         ],
+        "z6qtwf": "b",
       }
     `)
   })

--- a/src/effector/__tests__/fork/allSettled.test.ts
+++ b/src/effector/__tests__/fork/allSettled.test.ts
@@ -30,17 +30,14 @@ test('allSettled first argument validation', async () => {
   ).resolves.toBeUndefined()
 
   await expect(
-    // @ts-expect-error
-    allSettled(createStore(0), {scope: fork()}),
-  ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"first argument accepts only effects and events"`,
-  )
+    allSettled(createStore(0), {scope: fork(), params: 10}),
+  ).resolves.toBeUndefined()
 
   await expect(
     // @ts-expect-error
     allSettled(createDomain(), {scope: fork()}),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"first argument accepts only effects and events"`,
+    `"first argument accepts only effects, events and stores"`,
   )
 })
 

--- a/src/effector/fork/allSettled.ts
+++ b/src/effector/fork/allSettled.ts
@@ -10,8 +10,8 @@ export function allSettled<T>(
 ) {
   if (!is.unit(start))
     return Promise.reject(new Error('first argument should be unit'))
-  if (!is.effect(start) && !is.event(start))
-    return Promise.reject(new Error('first argument accepts only effects and events'))
+  if (!is.effect(start) && !is.event(start) && !is.store(start))
+    return Promise.reject(new Error('first argument accepts only effects, events and stores'))
   const defer = createDefer()
   //@ts-expect-error
   defer.parentFork = forkPage

--- a/src/effector/fork/allSettled.ts
+++ b/src/effector/fork/allSettled.ts
@@ -2,33 +2,35 @@ import {add} from '../collection'
 import {createDefer} from '../defer'
 import {is} from '../is'
 import {launch, forkPage} from '../kernel'
-import type {Scope} from '../unit.h'
+import type {Scope, Event, Effect, DataCarrier} from '../unit.h'
 
-export function allSettled(
-  start,
-  {scope, params: ctx}: {scope: Scope; params?},
+export function allSettled<T>(
+  start: Event<T> | Effect<T, any, any>,
+  {scope, params: ctx}: {scope: Scope; params?: unknown},
 ) {
   if (!is.unit(start))
-    return Promise.reject(Error('first argument should be unit'))
+    return Promise.reject(new Error('first argument should be unit'))
+  if (!is.effect(start) && !is.event(start))
+    return Promise.reject(new Error('first argument accepts only effects and events'))
   const defer = createDefer()
   //@ts-expect-error
   defer.parentFork = forkPage
   const {fxCount} = scope
   add(fxCount.scope.defers, defer)
 
-  const launchUnits = [start]
-  const launchParams = [] as Array<{params; req} | null>
+  const launchUnits: DataCarrier[] = [start]
+  const launchParams = [] as Array<{params: unknown; req: unknown} | null>
   add(
     launchParams,
     is.effect(start)
       ? {
           params: ctx,
           req: {
-            rs(value) {
+            rs(value: unknown) {
               //@ts-expect-error
               defer.value = {status: 'done', value}
             },
-            rj(value) {
+            rj(value: unknown) {
               //@ts-expect-error
               defer.value = {status: 'fail', value}
             },

--- a/src/effector/fork/allSettled.ts
+++ b/src/effector/fork/allSettled.ts
@@ -2,35 +2,33 @@ import {add} from '../collection'
 import {createDefer} from '../defer'
 import {is} from '../is'
 import {launch, forkPage} from '../kernel'
-import type {Scope, Event, Effect, DataCarrier} from '../unit.h'
+import type {Scope} from '../unit.h'
 
-export function allSettled<T>(
-  start: Event<T> | Effect<T, any, any>,
-  {scope, params: ctx}: {scope: Scope; params?: unknown},
+export function allSettled(
+  start,
+  {scope, params: ctx}: {scope: Scope; params?},
 ) {
   if (!is.unit(start))
-    return Promise.reject(new Error('first argument should be unit'))
-  if (!is.effect(start) && !is.event(start))
-    return Promise.reject(new Error('first argument accepts only effects and events'))
+    return Promise.reject(Error('first argument should be unit'))
   const defer = createDefer()
   //@ts-expect-error
   defer.parentFork = forkPage
   const {fxCount} = scope
   add(fxCount.scope.defers, defer)
 
-  const launchUnits: DataCarrier[] = [start]
-  const launchParams = [] as Array<{params: unknown; req: unknown} | null>
+  const launchUnits = [start]
+  const launchParams = [] as Array<{params; req} | null>
   add(
     launchParams,
     is.effect(start)
       ? {
           params: ctx,
           req: {
-            rs(value: unknown) {
+            rs(value) {
               //@ts-expect-error
               defer.value = {status: 'done', value}
             },
-            rj(value: unknown) {
+            rj(value) {
               //@ts-expect-error
               defer.value = {status: 'fail', value}
             },

--- a/src/effector/fork/createScope.ts
+++ b/src/effector/fork/createScope.ts
@@ -50,11 +50,12 @@ export function createScope(unit?: Domain): Scope {
     node: [
       calc((value, __, stack) => {
         const storeStack = getParent(stack)
-        if (storeStack && getParent(storeStack)) {
+        if (storeStack) {
           const storeNode = storeStack.node
           if (
             !getMeta(storeNode, 'isCombine') ||
-            getMeta(getParent(storeStack).node, 'op') !== 'combine'
+            (getParent(storeStack) &&
+              getMeta(getParent(storeStack).node, 'op') !== 'combine')
           ) {
             const forkPage = getForkPage(stack)!
             const id = storeNode.scope.state.id


### PR DESCRIPTION
Fixes #608 (by fixing serialize issue)

Changelog:
- added tests for `allSettled($store, ...)` cases
- added fix for the case

Apparently, the `getParent(storeStack)` line in `storeChange` node defintion is needed to check, if store is created from combine or map, but the same check also led to `$store` as starting unit for `allSettled` being skipped in serialization - because there is no "parent trigger" 🤔 