### PR TITLE
added: edge case for split

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -731,13 +731,12 @@ type SplitType<
 
       : {error: 'not implemented'}
 
-  : UnitValue<Match> extends CaseTypeReader<Cases, keyof Cases>
-    ? Config
-    : {
-        error: 'source type should extends cases'
-        sourceType: UnitValue<Source>
-        caseType: CaseTypeReader<Cases, keyof Cases>
-      }
+  : {
+    error: 'source type should extends cases'
+    sourceType: UnitValue<Source>
+    caseType: CaseTypeReader<Cases, keyof Cases>
+  }
+
 /**
  * Chooses one of cases by given conditions. It "splits" source unit into several targets, which fires when payload matches their conditions.
  * Works like pattern matching for payload values and external units

--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -731,12 +731,13 @@ type SplitType<
 
       : {error: 'not implemented'}
 
-  : {
-    error: 'source type should extends cases'
-    sourceType: UnitValue<Source>
-    caseType: CaseTypeReader<Cases, keyof Cases>
-  }
-
+  : UnitValue<Match> extends CaseTypeReader<Cases, keyof Cases>
+    ? Config
+    : {
+        error: 'source type should extends cases'
+        sourceType: UnitValue<Source>
+        caseType: CaseTypeReader<Cases, keyof Cases>
+      }
 /**
  * Chooses one of cases by given conditions. It "splits" source unit into several targets, which fires when payload matches their conditions.
  * Works like pattern matching for payload values and external units

--- a/src/types/__tests__/effector/split.test.ts
+++ b/src/types/__tests__/effector/split.test.ts
@@ -1,5 +1,13 @@
 /* eslint-disable no-unused-vars */
-import {createEvent, createStore, Event, guard, split, attach} from 'effector'
+import {
+  createEvent,
+  createStore,
+  Event,
+  guard,
+  split,
+  attach,
+  sample,
+} from 'effector'
 
 const typecheck = '{global}'
 
@@ -1237,6 +1245,31 @@ describe('array cases', () => {
         Argument of type '{ source: Event<{ foo: 1; }>; match: (src: any) => \\"a\\"; cases: { a: Event<{ foo: 1; bar: number; }>[]; b: Event<{ foo: 1; bar: string; }>[]; }; }' is not assignable to parameter of type '{ error: \\"source type should extends cases\\"; sourceType: { foo: 1; }; caseType: { foo: 1; bar: number; } | { foo: 1; bar: string; }; }'.
           Object literal may only specify known properties, and 'source' does not exist in type '{ error: \\"source type should extends cases\\"; sourceType: { foo: 1; }; caseType: { foo: 1; bar: number; } | { foo: 1; bar: string; }; }'.
         Parameter 'src' implicitly has an 'any' type.
+        "
+      `)
+    })
+
+    test('source doesnt satisfy cases but match do it', () => {
+      const source = sample({
+        clock: createEvent<number | null>(),
+        source: createStore<number | null>(1),
+        fn: ($value, evtPayload) => ({a: $value, b: evtPayload}),
+      })
+      const cases = {
+        write: createEvent<{a: number; b: number}>(),
+      }
+
+      split({
+        source,
+        match: {
+          write: data => data.a !== null && data.b !== null,
+        },
+        cases,
+      })
+
+      expect(typecheck).toMatchInlineSnapshot(`
+        "
+        no errors
         "
       `)
     })

--- a/src/types/__tests__/effector/split.test.ts
+++ b/src/types/__tests__/effector/split.test.ts
@@ -1249,7 +1249,7 @@ describe('array cases', () => {
       `)
     })
 
-    test('source doesnt satisfy cases but match do it', () => {
+    test('source doesnt satisfy cases but match do it (should fail)', () => {
       const source = sample({
         clock: createEvent<number | null>(),
         source: createStore<number | null>(1),
@@ -1260,16 +1260,20 @@ describe('array cases', () => {
       }
 
       split({
+        //@ts-expect-error
         source,
         match: {
-          write: data => data.a !== null && data.b !== null,
+          //@ts-expect-error src is any
+          write: src => src.a !== null && src.b !== null,
         },
         cases,
       })
 
       expect(typecheck).toMatchInlineSnapshot(`
         "
-        no errors
+        Argument of type '{ source: Event<{ a: number | null; b: number | null; }>; match: { write: (src: any) => boolean; }; cases: { write: Event<{ a: number; b: number; }>; }; }' is not assignable to parameter of type '{ error: \\"source type should extends cases\\"; sourceType: { a: number | null; b: number | null; }; caseType: { a: number; b: number; }; }'.
+          Object literal may only specify known properties, and 'source' does not exist in type '{ error: \\"source type should extends cases\\"; sourceType: { a: number | null; b: number | null; }; caseType: { a: number; b: number; }; }'.
+        Parameter 'src' implicitly has an 'any' type.
         "
       `)
     })


### PR DESCRIPTION


I'm not sure but we probably need to check that  `UnitValue<Match> extends CaseTypeReader<Cases, keyof Cases>` in the first SplitType fork.

I doubt it because I see the failed tests. Maybe that's how it was supposed to be 