### PR TITLE
Fix attach operator with plain function case defails in documentation

### DIFF
--- a/docs/api/effector/attach.md
+++ b/docs/api/effector/attach.md
@@ -166,7 +166,7 @@ resultFx = attach({
 **Arguments**
 
 - `effect` (_Function_): `(source: Source, params: Params) => Promise<Result> | Result`
-- `source` ([_Store_](Store.md) | `{[key: string]: Store}`): Store or object with stores, values of which will be passed to the second argument of `mapParams`
+- `source` ([_Store_](Store.md) | `{[key: string]: Store}`): Store or object with stores, values of which will be passed to the first argument of `effect`
 
 **Returns**
 

--- a/website/client/i18n/ru/docusaurus-plugin-content-docs/current/api/effector/attach.md
+++ b/website/client/i18n/ru/docusaurus-plugin-content-docs/current/api/effector/attach.md
@@ -166,7 +166,7 @@ resultFx = attach({
 **Arguments**
 
 - `effect` (_Function_): `(source: Source, params: Params) => Promise<Result> | Result`
-- `source` ([_Store_](Store.md) | `{[key: string]: Store}`): Store or object with stores, values of which will be passed to the second argument of `mapParams`
+- `source` ([_Store_](Store.md) | `{[key: string]: Store}`): Store or object with stores, values of which will be passed to the first argument of `effect`
 
 **Returns**
 


### PR DESCRIPTION
[documentation] `attach` operator has an overload with plain function as `effect` option. Clarify relation of `source` option to `effect` one in this case.