### PR TITLE
docs: switch unpkg to jsdelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,11 @@ Svelte works with effector out of the box, no additional packages needed. See [w
 
 **CDN**
 
-- https://unpkg.com/effector/effector.cjs.js
-- https://unpkg.com/effector/effector.mjs
-- https://unpkg.com/effector-react/effector-react.cjs.js
-- https://unpkg.com/effector-vue/effector-vue.cjs.js
+- https://www.jsdelivr.com/package/npm/effector
+- https://cdn.jsdelivr.net/npm/effector/effector.cjs.js
+- https://cdn.jsdelivr.net/npm/effector/effector.mjs
+- https://cdn.jsdelivr.net/npm/effector-react/effector-react.cjs.js
+- https://cdn.jsdelivr.net/npm/effector-vue/effector-vue.cjs.js
 
 ## Documentation
 

--- a/docs/introduction/installation.mdx
+++ b/docs/introduction/installation.mdx
@@ -33,7 +33,7 @@ yarn add effector
 Import `effector.mjs` from any CDN
 
 ```typescript
-import {createStore} from 'https://unpkg.com/effector/effector.mjs'
+import {createStore} from 'https://cdn.jsdelivr.net/npm/effector/effector.mjs'
 ```
 
 :::note since

--- a/examples/cdn.html
+++ b/examples/cdn.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="https://unpkg.com/effector@0.18.2/effector.umd.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/effector@0.18.2/effector.umd.js"></script>
   </head>
   <body>
     <script>

--- a/website/client/i18n/ru/docusaurus-plugin-content-docs/current/introduction/installation.mdx
+++ b/website/client/i18n/ru/docusaurus-plugin-content-docs/current/introduction/installation.mdx
@@ -34,7 +34,7 @@ yarn add effector
 Можно импортировать `effector.mjs` с любого CDN, например так:
 
 ```typescript
-import {createStore} from 'https://unpkg.com/effector/effector.mjs'
+import {createStore} from 'https://cdn.jsdelivr.net/npm/effector/effector.mjs'
 ```
 
 :::note 


### PR DESCRIPTION
I think it'd be appropriate for effector to update its CDN documentation.

unpkg is unmaintained and [full of issues](https://github.com/mjackson/unpkg/issues). I switched the documentation over to [jsDelivr](https://www.jsdelivr.com/) since it's actively maintained and is much more reliable due to its [fallback system](https://www.jsdelivr.com/network/infographic).

Let me know if there are any concerns!