### PR TITLE
website: rename REPL in Playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 <p align="center">
   <a href="https://gitter.im/effector/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge"><img src="https://badges.gitter.im/effector/community.svg" alt="join gitter" /></a>
   <a href="https://openbase.com/js/effector?utm_source=embedded&utm_medium=badge&utm_campaign=rate-badge"><img src="https://badges.openbase.com/js/rating/effector.svg" alt="rate on openbase" /></a>
-  <a href="https://github.com/effector/effector/actions/workflows/tests.yml"><img src="https://github.com/effector/effector/actions/workflows/tests.yml/badge.svg?branch=master" alt="build status" /></a>  
+  <a href="https://github.com/effector/effector/actions/workflows/tests.yml"><img src="https://github.com/effector/effector/actions/workflows/tests.yml/badge.svg?branch=master" alt="build status" /></a>
   <a href="https://discord.gg/t3KkcQdt"><img src="https://img.shields.io/badge/chat-discord-blue?style=flat&logo=discord" alt="discord chat"></a>
   <a href="https://www.patreon.com/zero_bias/overview"><img src="https://img.shields.io/badge/become-a%20patron-%23f96854" alt="become a patron" /></a>
 </p>
 
 
-# ☄️ effector 
+# ☄️ effector
 
 Business logic with ease
 
@@ -117,9 +117,9 @@ For additional information, guides and api reference visit [our documentation si
 
 ## Online playground
 
-You can try effector in [our repl](https://share.effector.dev)
+You can try effector with [online playground](https://share.effector.dev)
 
-Code sharing, Typescript and react supported out of the box. [REPL repository](https://github.com/effector/repl)
+Code sharing, Typescript and react supported out of the box. [Playground repository](https://github.com/effector/repl)
 
 ## DevTools
 

--- a/website/client/docusaurus.config.js
+++ b/website/client/docusaurus.config.js
@@ -38,7 +38,7 @@ module.exports = {
         },
         {
           href: 'https://share.effector.dev',
-          label: 'REPL',
+          label: 'Playground',
           position: 'left',
         },
         {

--- a/website/client/i18n/ru/code.json
+++ b/website/client/i18n/ru/code.json
@@ -21,7 +21,7 @@
   },
   "landing.try_it": {
     "message": "Попробовать онлайн",
-    "description": "Try it out"
+    "description": "Playground"
   },
   "landing.video_introduction": {
     "message": "Видеоурок",

--- a/website/client/i18n/ru/docusaurus-theme-classic/navbar.json
+++ b/website/client/i18n/ru/docusaurus-theme-classic/navbar.json
@@ -15,9 +15,9 @@
     "message": "Блог",
     "description": "Navbar item with label Blog"
   },
-  "item.label.REPL": {
-    "message": "REPL",
-    "description": "Navbar item with label REPL"
+  "item.label.Playground": {
+    "message": "Попробовать онлайн",
+    "description": "Navbar item with label Playground"
   },
   "item.label.Changelog": {
     "message": "Что нового",

--- a/website/client/i18n/zh-cn/code.json
+++ b/website/client/i18n/zh-cn/code.json
@@ -21,7 +21,7 @@
   },
   "landing.try_it": {
     "message": "在线试用",
-    "description": "Try it out"
+    "description": "Playground"
   },
   "landing.video_introduction": {
     "message": "视频教程",

--- a/website/client/i18n/zh-cn/docusaurus-theme-classic/navbar.json
+++ b/website/client/i18n/zh-cn/docusaurus-theme-classic/navbar.json
@@ -15,9 +15,9 @@
     "message": "博客",
     "description": "Navbar item with label Blog"
   },
-  "item.label.REPL": {
-    "message": "REPL",
-    "description": "Navbar item with label REPL"
+  "item.label.Playground": {
+    "message": "在线试用",
+    "description": "Navbar item with label Playground"
   },
   "item.label.Changelog": {
     "message": "更新日志",

--- a/website/client/src/pages/index.js
+++ b/website/client/src/pages/index.js
@@ -47,8 +47,8 @@ $status.watch(status => {
 
 nextPost()
 
-// => Loading post... 
-// => Post 2 has 5 comments 
+// => Loading post...
+// => Post 2 has 5 comments
 `,
   ru: `import {createEvent, createStore, createEffect, combine, sample} from 'effector'
 
@@ -88,8 +88,8 @@ $status.watch(status => {
 
 nextPost()
 
-// => Загрузка поста... 
-// => Пост 2 имеет 5 комментариев 
+// => Загрузка поста...
+// => Пост 2 имеет 5 комментариев
 `,
   "zh-cn": `import {createEvent, createStore, createEffect, combine, sample} from 'effector'
 
@@ -129,8 +129,8 @@ $status.watch(status => {
 
 nextPost()
 
-// => Loading post... 
-// => Post 2 has 5 comments 
+// => Loading post...
+// => Post 2 has 5 comments
 `
 }
 
@@ -468,8 +468,8 @@ function Hero() {
               <Link
                 className="button button--outline button--secondary button--lg"
                 to="https://share.effector.dev">
-                <Translate id="landing.try_it" description="Try it out">
-                  Try it out
+                <Translate id="landing.try_it" description="Playground">
+                  Playground
                 </Translate>
               </Link>
             </div>


### PR DESCRIPTION
Following discussion, I've renamed "REPL" term to "Playground".

Also changed button "Try it out" to "Playground", for consistency. Discussible.

For Russian and Chinese localizations I've renamed "REPL" to what is written on "Try it out" button — "Попробовать онлайн" and "在线试用" accordingly.