### PR TITLE
Fix packages links in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ For additional information, guides and api reference visit [our documentation si
 
 ## Packages
 
-- [effector](https://effector.dev/docs/api/effector/effector)
-- [effector-react](https://effector.dev/docs/api/effector-react/effector-react)
-- [effector-vue](https://effector.dev/docs/api/effector-vue/effector-vue)
+- [effector](https://effector.dev/docs/api/effector)
+- [effector-react](https://effector.dev/docs/api/effector-react)
+- [effector-vue](https://effector.dev/docs/api/effector-vue)
 
 ## Articles
 


### PR DESCRIPTION
Whenever navigate by links from packages sections, page not found appears

### Conventions
- [ ] Please check your messages [against the guidelines](https://cbea.ms/git-commit/) if not, perform [interactive rebase](https://thoughtbot.com/blog/git-interactive-rebase-squash-amend-rewriting-history)
- [ ] [Link an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) your pull request closes or relates
