### PR TITLE
Fix react scope behavior

### DIFF
--- a/src/react/__tests__/base/scopes.test.tsx
+++ b/src/react/__tests__/base/scopes.test.tsx
@@ -1124,3 +1124,82 @@ test('useUnit should bind units to scope', async () => {
   expect(scopeB.getState($a)).toEqual(0)
   expect($a.getState()).toEqual(0)
 })
+
+describe('hooks throw errors, if Provider is not found', () => {
+  test('useUnit from `effector-react/scope` throws error, if no Provider', () => {
+    const $a = createStore(42)
+
+    const View = () => {
+      const a = useUnit($a)
+
+      return <div>{a}</div>
+    }
+
+    expect(() => render(<View />)).rejects.toThrow(
+      'No scope found, consider adding <Provider> to app root',
+    )
+  })
+
+  test('useStore from `effector-react/scope` throws error, if no Provider', () => {
+    const $a = createStore(42)
+
+    const View = () => {
+      const a = useStore($a)
+
+      return <div>{a}</div>
+    }
+
+    expect(() => render(<View />)).rejects.toThrow(
+      'No scope found, consider adding <Provider> to app root',
+    )
+  })
+
+  test('useEvent from `effector-react/scope` throws error, if no Provider', () => {
+    const ev = createEvent()
+
+    const View = () => {
+      const a = useEvent(ev)
+
+      return <div onClick={a}></div>
+    }
+
+    expect(() => render(<View />)).rejects.toThrow(
+      'No scope found, consider adding <Provider> to app root',
+    )
+  })
+
+  test('useStoreMap from `effector-react/scope` throws error, if no Provider', () => {
+    const $a = createStore(42)
+
+    const View = () => {
+      const a = useStoreMap({
+        store: $a,
+        keys: [],
+        fn: () => 42,
+        defaultValue: 77,
+      })
+
+      return <div>{a}</div>
+    }
+
+    expect(() => render(<View />)).rejects.toThrow(
+      'No scope found, consider adding <Provider> to app root',
+    )
+  })
+
+  test('useList from `effector-react/scope` throws error, if no Provider', () => {
+    const $a = createStore([42])
+
+    const View = () => {
+      const a = useList($a, {
+        fn: () => <div>42</div>,
+      })
+
+      return <div>{a}</div>
+    }
+
+    expect(() => render(<View />)).rejects.toThrow(
+      'No scope found, consider adding <Provider> to app root',
+    )
+  })
+})

--- a/src/react/ssr.ts
+++ b/src/react/ssr.ts
@@ -92,18 +92,18 @@ export const connect = (Component: any) => (store: any) => {
 
 /** useStore wrapper for scopes */
 export function useStore<T>(store: Store<T>): T {
-  return useStoreBase(store, getScope())
+  return useStoreBase(store, getScope(true))
 }
 export function useUnit(shape) {
-  return useUnitBase(shape, getScope())
+  return useUnitBase(shape, getScope(true))
 }
 /** useList wrapper for scopes */
 export function useList(store: any, opts: any) {
-  return useListBase(store, opts, getScope())
+  return useListBase(store, opts, getScope(true))
 }
 /** useStoreMap wrapper for scopes */
 export function useStoreMap(configOrStore: any, separateFn: any) {
-  const scope = getScope()
+  const scope = getScope(true)
   if (separateFn) return useStoreMapBase([configOrStore, separateFn], scope)
   return useStoreMapBase(
     [
@@ -124,7 +124,7 @@ bind event to scope
 works like React.useCallback, but for scopes
 */
 export function useEvent(eventObject: any) {
-  const scope = getScope()
+  const scope = getScope(true)
   const isShape = !is.unit(eventObject) && typeof eventObject === 'object'
   const events = isShape ? eventObject : {event: eventObject}
 


### PR DESCRIPTION
Recent PR introduced a breaking change - `effector-react/scope` lost its warnings against usage without `Provider`

This PR reintroduces this behavior and adds some tests for that.