### PR TITLE
Isomorphic React, part 3

### DIFF
--- a/packages/effector-react/index.d.ts
+++ b/packages/effector-react/index.d.ts
@@ -130,14 +130,25 @@ export function createReactState<
   Com extends React.ComponentType<any>,
 >(store: Store<State>, Component: Com): React.ComponentType<State>
 
-export function useEvent(event: Event<void>): () => void
-export function useEvent<T>(event: Event<T>): (payload: T) => T
-export function useEvent<R>(fx: Effect<void, R, any>): () => Promise<R>
+export function useEvent(
+  event: Event<void>,
+  opts?: {forceScope?: boolean},
+): () => void
+export function useEvent<T>(
+  event: Event<T>,
+  opts?: {forceScope?: boolean},
+): (payload: T) => T
+export function useEvent<R>(
+  fx: Effect<void, R, any>,
+  opts?: {forceScope?: boolean},
+): () => Promise<R>
 export function useEvent<T, R>(
   fx: Effect<T, R, any>,
+  opts?: {forceScope?: boolean},
 ): (payload: T) => Promise<R>
 export function useEvent<List extends (Event<any> | Effect<any, any>)[]>(
   list: [...List],
+  opts?: {forceScope?: boolean},
 ): {
   [Key in keyof List]: List[Key] extends Event<infer T>
     ? (payload: T) => T
@@ -149,6 +160,7 @@ export function useEvent<
   Shape extends Record<string, Event<any> | Effect<any, any, any>>,
 >(
   shape: Shape,
+  opts?: {forceScope?: boolean},
 ): {
   [Key in keyof Shape]: Shape[Key] extends Event<infer T>
     ? (payload: T) => T

--- a/packages/effector-react/index.d.ts
+++ b/packages/effector-react/index.d.ts
@@ -32,6 +32,7 @@ export function useStoreMap<
   readonly fn: (state: State, keys: Keys) => Result | undefined
   readonly updateFilter?: (update: Result, current: Result) => boolean
   readonly defaultValue: Result
+  readonly forceScope?: boolean
 }): Result
 export function useStoreMap<
   State,
@@ -42,6 +43,7 @@ export function useStoreMap<
   readonly keys: Keys
   readonly fn: (state: State, keys: Keys) => Result
   readonly updateFilter?: (update: Result, current: Result) => boolean
+  readonly forceScope?: boolean
 }): Result
 export function useStoreMap<State, Result>(
   store: Store<State>,

--- a/packages/effector-react/index.d.ts
+++ b/packages/effector-react/index.d.ts
@@ -57,7 +57,7 @@ export function useList<T, Key extends React.Key>(
     readonly getKey: (item: T) => Key
     readonly placeholder?: React.ReactNode
   },
-  {forceScope}: {forceScope?: boolean},
+  {forceScope}?: {forceScope?: boolean},
 ): JSX.Element
 export function useList<T>(
   list: Store<T[]> | Store<ReadonlyArray<T>>,
@@ -68,7 +68,7 @@ export function useList<T>(
         readonly placeholder?: React.ReactNode
       }
     | ((item: T, index: number) => React.ReactNode),
-  {forceScope}: {forceScope?: boolean},
+  {forceScope}?: {forceScope?: boolean},
 ): JSX.Element
 
 export function useGate<Props>(Gate: Gate<Props>, props?: Props): void

--- a/packages/effector-react/index.d.ts
+++ b/packages/effector-react/index.d.ts
@@ -57,6 +57,7 @@ export function useList<T, Key extends React.Key>(
     readonly getKey: (item: T) => Key
     readonly placeholder?: React.ReactNode
   },
+  {forceScope}: {forceScope?: boolean},
 ): JSX.Element
 export function useList<T>(
   list: Store<T[]> | Store<ReadonlyArray<T>>,
@@ -67,6 +68,7 @@ export function useList<T>(
         readonly placeholder?: React.ReactNode
       }
     | ((item: T, index: number) => React.ReactNode),
+  {forceScope}: {forceScope?: boolean},
 ): JSX.Element
 
 export function useGate<Props>(Gate: Gate<Props>, props?: Props): void

--- a/packages/effector-react/index.d.ts
+++ b/packages/effector-react/index.d.ts
@@ -18,7 +18,10 @@ export type StoreView<State, Props = {}> = React.ComponentType<Props> & {
   unmounted: Event<{props: Props; state: State}>
 }
 
-export function useStore<State>(store: Store<State>): State
+export function useStore<State>(
+  store: Store<State>,
+  opts?: {forceScope?: boolean},
+): State
 export function useStoreMap<
   State,
   Result,

--- a/packages/effector-react/scope.d.ts
+++ b/packages/effector-react/scope.d.ts
@@ -1,42 +1,15 @@
-import * as React from 'react'
-import {Event, Effect, Scope, Domain, Store} from 'effector'
+import {Domain} from 'effector'
 import {Gate} from 'effector-react'
 
-export {useStore, useStoreMap, useList, useGate, useUnit} from 'effector-react'
-
-export const Provider: React.Provider<Scope>
-
-/**
-bind event to scope
-
-works like React.useCallback, but for scopes
-*/
-export function useEvent(event: Event<void>): () => void
-export function useEvent<T>(event: Event<T>): (payload: T) => T
-export function useEvent<R>(fx: Effect<void, R, any>): () => Promise<R>
-export function useEvent<T, R>(
-  fx: Effect<T, R, any>,
-): (payload: T) => Promise<R>
-export function useEvent<List extends (Event<any> | Effect<any, any>)[]>(
-  list: [...List],
-): {
-  [Key in keyof List]: List[Key] extends Event<infer T>
-    ? (payload: T) => T
-    : List[Key] extends Effect<infer P, infer D, any>
-    ? (payload: P) => Promise<D>
-    : never
-}
-export function useEvent<
-  Shape extends Record<string, Event<any> | Effect<any, any, any>>,
->(
-  shape: Shape,
-): {
-  [Key in keyof Shape]: Shape[Key] extends Event<infer T>
-    ? (payload: T) => T
-    : Shape[Key] extends Effect<infer P, infer D, any>
-    ? (payload: P) => Promise<D>
-    : never
-}
+export {
+  useStore,
+  useStoreMap,
+  useList,
+  useGate,
+  useUnit,
+  useEvent,
+  Provider,
+} from 'effector-react'
 
 export function createGate<State>(config: {
   domain?: Domain

--- a/src/react/__tests__/base/useEvent.test.tsx
+++ b/src/react/__tests__/base/useEvent.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+//@ts-ignore
+import {render, container, act} from 'effector/fixtures/react'
+import {createEvent, fork, createWatch} from 'effector'
+import {Provider, useEvent} from 'effector-react'
+
+describe('useEvent', () => {
+  test('bind event to scope if Provider is used', async () => {
+    const event = createEvent()
+
+    const scope = fork()
+
+    const watcher = jest.fn()
+
+    createWatch({unit: event, fn: watcher, scope})
+
+    function App() {
+      const handler = useEvent(event)
+
+      return <button onClick={handler}>Click me</button>
+    }
+
+    await render(
+      <Provider value={scope}>
+        <App />
+      </Provider>,
+    )
+
+    await act(async () => {
+      container.firstChild?.click()
+    })
+
+    expect(watcher).toHaveBeenCalledTimes(1)
+  })
+
+  test('throw error if Provider is not used with forceScope', async () => {
+    const event = createEvent()
+
+    function App() {
+      const handler = useEvent(event, {forceScope: true})
+
+      return <button onClick={handler}>Click me</button>
+    }
+
+    expect(() => render(<App />)).rejects.toMatchInlineSnapshot(
+      `[Error: No scope found, consider adding <Provider> to app root]`,
+    )
+  })
+
+  test('return event as is for no Provider', async () => {
+    const event = createEvent()
+
+    const watcher = jest.fn()
+
+    createWatch({unit: event, fn: watcher})
+
+    function App() {
+      const handler = useEvent(event)
+
+      return <button onClick={handler}>Click me</button>
+    }
+
+    await render(<App />)
+
+    await act(async () => {
+      container.firstChild?.click()
+    })
+
+    expect(watcher).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/react/__tests__/base/useList.test.tsx
+++ b/src/react/__tests__/base/useList.test.tsx
@@ -8,9 +8,10 @@ import {
   restore,
   createApi,
   createEffect,
+  fork,
 } from 'effector'
 
-import {useList, useStore} from 'effector-react'
+import {Provider, useList, useStore} from 'effector-react'
 import {argumentHistory} from 'effector/fixtures'
 
 it('should render store items', async () => {
@@ -588,4 +589,44 @@ test('placeholder', async () => {
       </div>
     </div>
   `)
+})
+
+test('get value from scope if it is available', async () => {
+  const $store = createStore(['original'])
+
+  const scope = fork({values: [[$store, ['scoped']]]})
+
+  function App() {
+    const value = useList($store, t => <li>{t}</li>)
+
+    return <ol>{value}</ol>
+  }
+
+  await render(
+    <Provider value={scope}>
+      <App />
+    </Provider>,
+  )
+
+  expect(container.firstChild).toMatchInlineSnapshot(`
+    <ol>
+      <li>
+        scoped
+      </li>
+    </ol>
+  `)
+})
+
+test('throw error on forceScope if it is not available', async () => {
+  const $store = createStore(['original'])
+
+  function App() {
+    const value = useList($store, t => <li>{t}</li>, {forceScope: true})
+
+    return <ol>{value}</ol>
+  }
+
+  expect(() => render(<App />)).rejects.toMatchInlineSnapshot(
+    `[Error: No scope found, consider adding <Provider> to app root]`,
+  )
 })

--- a/src/react/__tests__/base/useStore.test.tsx
+++ b/src/react/__tests__/base/useStore.test.tsx
@@ -9,8 +9,9 @@ import {
   Store,
   Event,
   restore,
+  fork,
 } from 'effector'
-import {useStore, useStoreMap} from 'effector-react'
+import {Provider, useStore, useStoreMap} from 'effector-react'
 import {argumentHistory} from 'effector/fixtures'
 
 describe('useStore', () => {
@@ -423,6 +424,44 @@ describe('useStore', () => {
         </div>
       `)
     })
+  })
+
+  test('get value from scope if it is available', async () => {
+    const $store = createStore('original')
+
+    const scope = fork({values: [[$store, 'scoped']]})
+
+    function App() {
+      const value = useStore($store)
+
+      return <p>{value}</p>
+    }
+
+    await render(
+      <Provider value={scope}>
+        <App />
+      </Provider>,
+    )
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <p>
+        scoped
+      </p>
+    `)
+  })
+
+  test('throw error on forceScope if it is not available', async () => {
+    const $store = createStore('original')
+
+    function App() {
+      const value = useStore($store, {forceScope: true})
+
+      return <p>{value}</p>
+    }
+
+    expect(() => render(<App />)).rejects.toMatchInlineSnapshot(
+      `[Error: No scope found, consider adding <Provider> to app root]`,
+    )
   })
 })
 describe('useStoreMap', () => {

--- a/src/react/__tests__/base/useStore.test.tsx
+++ b/src/react/__tests__/base/useStore.test.tsx
@@ -931,4 +931,51 @@ describe('useStoreMap', () => {
     })
     expect(argumentHistory(fn)).toEqual(['Guest', 'Bob', 'Guest'])
   })
+
+  test('get value from scope if it is available', async () => {
+    const $store = createStore('original')
+
+    const scope = fork({values: [[$store, 'scoped']]})
+
+    function App() {
+      const value = useStoreMap({
+        store: $store,
+        fn: t => t + 'mapped',
+        keys: [],
+      })
+
+      return <p>{value}</p>
+    }
+
+    await render(
+      <Provider value={scope}>
+        <App />
+      </Provider>,
+    )
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <p>
+        scopedmapped
+      </p>
+    `)
+  })
+
+  test('throw error on forceScope if it is not available', async () => {
+    const $store = createStore('original')
+
+    function App() {
+      const value = useStoreMap({
+        store: $store,
+        fn: t => t + 'mapped',
+        keys: [],
+        forceScope: true,
+      })
+
+      return <p>{value}</p>
+    }
+
+    expect(() => render(<App />)).rejects.toMatchInlineSnapshot(
+      `[Error: No scope found, consider adding <Provider> to app root]`,
+    )
+  })
 })

--- a/src/react/apiBase.ts
+++ b/src/react/apiBase.ts
@@ -304,3 +304,23 @@ export function useListBase<T>(
     )
   }
 }
+
+export function useEventBase(eventObject: any, scope?: Scope) {
+  if (!scope) {
+    return eventObject
+  }
+  const isShape = !is.unit(eventObject) && typeof eventObject === 'object'
+  const events = isShape ? eventObject : {event: eventObject}
+
+  return React.useMemo(() => {
+    if (is.unit(eventObject)) {
+      //@ts-expect-error
+      return scopeBind(eventObject, {scope})
+    }
+    const shape = Array.isArray(eventObject) ? [] : ({} as any)
+    for (const key in eventObject) {
+      shape[key] = scopeBind(eventObject[key], {scope})
+    }
+    return shape
+  }, [scope, ...Object.keys(events), ...Object.values(events)])
+}

--- a/src/react/nossr.ts
+++ b/src/react/nossr.ts
@@ -35,11 +35,15 @@ export function useStoreMap<State, Result, Keys extends ReadonlyArray<any>>(
         fn(state: State, keys: Keys): Result
         updateFilter?: (update: Result, current: Result) => boolean
         defaultValue?: Result
+        forceScope?: boolean
       }
     | Store<State>,
   separateFn?: (state: State, keys: Keys) => Result,
 ): Result {
-  return useStoreMapBase([configOrStore, separateFn])
+  return useStoreMapBase(
+    [configOrStore, separateFn],
+    getScope(configOrStore?.forceScope),
+  )
 }
 
 export function useList<T>(

--- a/src/react/nossr.ts
+++ b/src/react/nossr.ts
@@ -4,6 +4,7 @@ import {
   useStoreMapBase,
   useListBase,
   useUnitBase,
+  useEventBase,
 } from './apiBase'
 import {getScope} from './scope'
 
@@ -17,10 +18,8 @@ export function useEvent<T>(
   opts?: {forceScope?: boolean},
 ): (payload: T) => T {
   const scope = getScope(opts?.forceScope)
-  if (scope) {
-    return scopeBind(event, {scope})
-  }
-  return event
+
+  return useEventBase(event, scope)
 }
 
 export function useStore<State>(

--- a/src/react/nossr.ts
+++ b/src/react/nossr.ts
@@ -16,8 +16,11 @@ export function useEvent<T>(event: Event<T>): (payload: T) => T {
   return event
 }
 
-export function useStore<State>(store: Store<State>): State {
-  return useStoreBase(store)
+export function useStore<State>(
+  store: Store<State>,
+  opts?: {forceScope?: boolean},
+): State {
+  return useStoreBase(store, getScope(opts?.forceScope))
 }
 
 export function useUnit(shape, opts?: {forceScope?: boolean}) {

--- a/src/react/nossr.ts
+++ b/src/react/nossr.ts
@@ -56,6 +56,7 @@ export function useList<T>(
         placeholder?: React.ReactNode
       }
     | ((item: T, index: number) => React.ReactNode),
+  opts?: {forceScope?: boolean},
 ): React.ReactNode {
-  return useListBase(list, renderItem)
+  return useListBase(list, renderItem, getScope(opts?.forceScope))
 }

--- a/src/react/nossr.ts
+++ b/src/react/nossr.ts
@@ -1,4 +1,4 @@
-import {Event, Store} from 'effector'
+import {Event, scopeBind, Store} from 'effector'
 import {
   useStoreBase,
   useStoreMapBase,
@@ -12,7 +12,14 @@ bind event to scope
 
 works like React.useCallback, but for scopes
 */
-export function useEvent<T>(event: Event<T>): (payload: T) => T {
+export function useEvent<T>(
+  event: Event<T>,
+  opts?: {forceScope?: boolean},
+): (payload: T) => T {
+  const scope = getScope(opts?.forceScope)
+  if (scope) {
+    return scopeBind(event, {scope})
+  }
   return event
 }
 

--- a/src/react/nossr.ts
+++ b/src/react/nossr.ts
@@ -1,4 +1,4 @@
-import {Event, scopeBind, Store} from 'effector'
+import {Event, Store} from 'effector'
 import {
   useStoreBase,
   useStoreMapBase,

--- a/src/react/ssr.ts
+++ b/src/react/ssr.ts
@@ -5,6 +5,7 @@ import {
   useUnitBase,
   useStoreMapBase,
   useListBase,
+  useEventBase,
 } from './apiBase'
 import {withDisplayName} from './withDisplayName'
 import {
@@ -124,19 +125,5 @@ bind event to scope
 works like React.useCallback, but for scopes
 */
 export function useEvent(eventObject: any) {
-  const scope = getScope(true)
-  const isShape = !is.unit(eventObject) && typeof eventObject === 'object'
-  const events = isShape ? eventObject : {event: eventObject}
-
-  return React.useMemo(() => {
-    if (is.unit(eventObject)) {
-      //@ts-expect-error
-      return scopeBind(eventObject, {scope})
-    }
-    const shape = Array.isArray(eventObject) ? [] : ({} as any)
-    for (const key in eventObject) {
-      shape[key] = scopeBind(eventObject[key], {scope})
-    }
-    return shape
-  }, [scope, ...Object.keys(events), ...Object.values(events)])
+  return useEventBase(eventObject, getScope(true))
 }

--- a/src/react/ssr.ts
+++ b/src/react/ssr.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Domain, is, Store, scopeBind} from 'effector'
+import {Domain, Store} from 'effector'
 import {
   useStoreBase,
   useUnitBase,

--- a/src/types/__tests__/effector-react/effectorReact.test.tsx
+++ b/src/types/__tests__/effector-react/effectorReact.test.tsx
@@ -11,7 +11,6 @@ import {
 
 const typecheck = '{global}'
 
-
 test('createComponent', () => {
   const ImplicitObject = createComponent(
     {
@@ -60,7 +59,8 @@ test('createGate', () => {
 })
 
 test('useEvent of Event', () => {
-  const runEvent: (payload: number) => number = useEvent(createEvent<number>())
+  const runEvent: () => (payload: number) => number = () =>
+    useEvent(createEvent<number>())
   expect(typecheck).toMatchInlineSnapshot(`
     "
     no errors
@@ -69,7 +69,7 @@ test('useEvent of Event', () => {
 })
 
 test('useEvent of Event<void>', () => {
-  const runEvent: () => void = useEvent(createEvent<void>())
+  const runEvent: () => () => void = () => useEvent(createEvent<void>())
   expect(typecheck).toMatchInlineSnapshot(`
     "
     no errors
@@ -78,9 +78,8 @@ test('useEvent of Event<void>', () => {
 })
 
 test('useEvent of Effect', () => {
-  const runEffect: (payload: number) => Promise<string> = useEvent(
-    createEffect<number, string, Error>(),
-  )
+  const runEffect: () => (payload: number) => Promise<string> = () =>
+    useEvent(createEffect<number, string, Error>())
   expect(typecheck).toMatchInlineSnapshot(`
     "
     no errors
@@ -89,9 +88,8 @@ test('useEvent of Effect', () => {
 })
 
 test('useEvent of Effect<void, unknown, Error>', () => {
-  const runEffect: () => Promise<unknown> = useEvent(
-    createEffect<void, unknown, Error>(),
-  )
+  const runEffect: () => () => Promise<unknown> = () =>
+    useEvent(createEffect<void, unknown, Error>())
   expect(typecheck).toMatchInlineSnapshot(`
     "
     no errors
@@ -100,13 +98,14 @@ test('useEvent of Effect<void, unknown, Error>', () => {
 })
 
 test('useEvent of object', () => {
-  const handlers: {
+  const handlers: () => {
     foo: (payload: number) => number
     bar: (payload: number) => Promise<string>
-  } = useEvent({
-    foo: createEvent<number>(),
-    bar: createEffect<number, string, Error>(),
-  })
+  } = () =>
+    useEvent({
+      foo: createEvent<number>(),
+      bar: createEffect<number, string, Error>(),
+    })
   expect(typecheck).toMatchInlineSnapshot(`
     "
     no errors
@@ -115,10 +114,11 @@ test('useEvent of object', () => {
 })
 
 test('useEvent of array', () => {
-  const handlers: [
+  const handlers: () => [
     (payload: number) => number,
     (payload: number) => Promise<string>,
-  ] = useEvent([createEvent<number>(), createEffect<number, string, Error>()])
+  ] = () =>
+    useEvent([createEvent<number>(), createEffect<number, string, Error>()])
   expect(typecheck).toMatchInlineSnapshot(`
     "
     no errors
@@ -209,9 +209,7 @@ test('useUnit should correctly resolve void events and effects in shape mode', (
   const event = createEvent<void>()
   const effect = createEffect(() => {})
 
-  function x(callback: (e: unknown) => void | Promise<void>) {
-
-  }
+  function x(callback: (e: unknown) => void | Promise<void>) {}
 
   const Comp = () => {
     const {runEvent} = useUnit({runEvent: event})
@@ -236,9 +234,7 @@ test('useUnit should correctly resolve any type except void events and effects i
   const event = createEvent<boolean>()
   const effect = createEffect((_: boolean) => _)
 
-  function x(callback: (e: boolean) => boolean | Promise<boolean>) {
-
-  }
+  function x(callback: (e: boolean) => boolean | Promise<boolean>) {}
 
   const Comp = () => {
     const {runEvent} = useUnit({runEvent: event})
@@ -331,4 +327,3 @@ test('useUnit should not allow wrong types for events or effects with arguments'
     "
   `)
 })
-

--- a/src/types/__tests__/effector-react/useStoreMap.test.tsx
+++ b/src/types/__tests__/effector-react/useStoreMap.test.tsx
@@ -96,12 +96,12 @@ describe('useStoreMap', () => {
       expect(typecheck).toMatchInlineSnapshot(`
         "
         No overload matches this call.
-          Overload 1 of 3, '(opts: { readonly store: Store<User[]>; readonly keys: [number, number]; readonly fn: (state: User[], keys: [number, number]) => null | undefined; readonly updateFilter?: ((update: null, current: null) => boolean) | undefined; readonly defaultValue: null; }): null', gave the following error.
+          Overload 1 of 3, '(opts: { readonly store: Store<User[]>; readonly keys: [number, number]; readonly fn: (state: User[], keys: [number, number]) => null | undefined; readonly updateFilter?: ((update: null, current: null) => boolean) | undefined; readonly defaultValue: null; readonly forceScope?: boolean | undefined; }): null', gave the following error.
             Type '[number, keyof User]' is not assignable to type '[number, number]'.
               Type at position 1 in source is not compatible with type at position 1 in target.
                 Type 'string' is not assignable to type 'number'.
                   Type 'string' is not assignable to type 'number'.
-          Overload 2 of 3, '(opts: { readonly store: Store<User[]>; readonly keys: [number, number]; readonly fn: (state: User[], keys: [number, number]) => null; readonly updateFilter?: ((update: null, current: null) => boolean) | undefined; }): null', gave the following error.
+          Overload 2 of 3, '(opts: { readonly store: Store<User[]>; readonly keys: [number, number]; readonly fn: (state: User[], keys: [number, number]) => null; readonly updateFilter?: ((update: null, current: null) => boolean) | undefined; readonly forceScope?: boolean | undefined; }): null', gave the following error.
             Type '[number, keyof User]' is not assignable to type '[number, number]'.
         Type 'unknown' is not assignable to type 'ReactNode'.
           Type 'unknown' is not assignable to type 'ReactPortal'.


### PR DESCRIPTION
Finalize changes in `effector-react` that was started in https://github.com/effector/effector/pull/776 and https://github.com/effector/effector/pull/785.

Since `effector-react` and `effector-react/scope` are both fully bundled, it is impossible to mix it in one project (because of different instances of React context), so we had to provide a way to use only `effector-react` for scope-full runtime.

Public changes:
1. Make `useStore` isomorphic
2. Make `useStoreMap` isomorphic
3. Make `useList` isomorphic
4. Make `useEvent` isomorphic

Internal changes:
Rewrite type tests of `useEvent` (now it is not call `useEvent`) because it is no React in test bundle for type-tests. @AlexandrHoroshih previously made the same for `useUnit` tests.