### PR TITLE
event<void> $store.reinit added

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -220,6 +220,7 @@ export interface Store<State> extends Unit<State> {
   compositeName: CompositeName
   shortName: string
   sid: string | null
+  reinit?: Event<void>
 }
 
 export const is: {

--- a/src/effector/createUnit.ts
+++ b/src/effector/createUnit.ts
@@ -351,6 +351,12 @@ export function createStore<State>(
   if (config?.domain) {
     config.domain.hooks.store(store)
   }
+
+  if (!derived) {
+    store.reinit = createEvent<void>();
+    store.reset(store.reinit);
+  }
+
   return store
 }
 

--- a/src/effector/unit.h.ts
+++ b/src/effector/unit.h.ts
@@ -74,6 +74,7 @@ export interface Store<State> extends Unit {
   graphite: Node
   updates: Event<State>
   compositeName: CompositeName
+  reinit?: Event<void>
 }
 
 export interface Effect<Params, Done, Fail = Error> extends Unit {

--- a/src/types/__tests__/effector/store.test.ts
+++ b/src/types/__tests__/effector/store.test.ts
@@ -149,6 +149,30 @@ describe('#reset', () => {
   })
 })
 
+describe("#reinit", () => {
+  test("simple case", () => {
+    const $store = createStore<Array<number>>([]);
+    const eventPush = createEvent<number>();
+    $store.on(eventPush, (store, item) => [...store, item]);
+    eventPush(1);
+    eventPush(2);
+    eventPush(3);
+    const before = $store.getState().length;
+    expect(before).toBe(3);
+    $store.reinit?.();
+
+    const after = $store.getState().length;
+    expect(after).toBe(0);
+
+    $store.off(eventPush);
+    expect(typecheck).toMatchInlineSnapshot(`
+      "
+      no errors
+      "
+    `);
+  })
+});
+
 test('#on', () => {
   const event = createEvent()
   const store = createStore(0)


### PR DESCRIPTION
`$store.reinit` - event to set default value into store

```typescript
const $store = createStore<Array<number>>([]);

sample({
  clock: someEffectFailed,
  target: $store.reinit
});

// subscribe on store reinit
sample({
  clock: $store.reinit,
  fn: () => console.log("store value set to default")
});
```

### Conventions
- [ ] Please check your messages [against the guidelines](https://cbea.ms/git-commit/) if not, perform [interactive rebase](https://thoughtbot.com/blog/git-interactive-rebase-squash-amend-rewriting-history)
- [ ] [Link an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) your pull request closes or relates
