### PR TITLE
Protect against combine argument being broken via Array.slice

### DIFF
--- a/src/effector/__tests__/combine.test.ts
+++ b/src/effector/__tests__/combine.test.ts
@@ -288,10 +288,10 @@ describe('doesn`t leak internal objects to transform function', () => {
     const inc = createEvent()
     const $a = createStore(0).on(inc, x => x + 1)
     const combined = combine([$a], (array: any) => {
-      if (array[1] === "injected") {
+      if (array[1] === 'injected') {
         fn(array[1])
       }
-      array[1] = "injected"
+      array[1] = 'injected'
       const mainSlice = array.slice
       array.slice = (...args: any[]) => {
         fn('slice')
@@ -317,6 +317,30 @@ describe('doesn`t leak internal objects to transform function', () => {
 
       return obj.a + 1
     })
+    inc()
+
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`Array []`)
+  })
+
+  test('combine + map', () => {
+    const fn = jest.fn()
+    const inc = createEvent()
+    const $a = createStore(0).on(inc, x => x + 1)
+    const $b = createStore(0).on(inc, x => x + 1)
+    const combined = combine([$a, $b]).map((array: any) => {
+      if (array[2] === 'injected') {
+        fn(array[2])
+      }
+      array[2] = 'injected'
+      const mainSlice = array.slice
+      array.slice = (...args: any[]) => {
+        fn('slice')
+        return mainSlice.apply(array, args)
+      }
+      return array[0] + 1
+    })
+    inc()
+    inc()
     inc()
 
     expect(argumentHistory(fn)).toMatchInlineSnapshot(`Array []`)

--- a/src/effector/__tests__/combine.test.ts
+++ b/src/effector/__tests__/combine.test.ts
@@ -282,16 +282,12 @@ it('doesn`t leak internal variables to transform function', () => {
   `)
 })
 
-describe('doesn`t leak internal objects to transform function', () => {
+describe('doesn`t fail with slice is not a function', () => {
   test('array', () => {
     const fn = jest.fn()
     const inc = createEvent()
     const $a = createStore(0).on(inc, x => x + 1)
     const combined = combine([$a], (array: any) => {
-      if (array[1] === 'injected') {
-        fn(array[1])
-      }
-      array[1] = 'injected'
       const mainSlice = array.slice
       array.slice = (...args: any[]) => {
         fn('slice')
@@ -304,34 +300,12 @@ describe('doesn`t leak internal objects to transform function', () => {
     expect(argumentHistory(fn)).toMatchInlineSnapshot(`Array []`)
   })
 
-  test('object', () => {
-    const fn = jest.fn()
-    const inc = createEvent()
-    const $a = createStore(0).on(inc, x => x + 1)
-    const combined = combine({a: $a}, (obj: any) => {
-      if (obj.injectedProp) {
-        fn(obj.injectedProp)
-      }
-
-      obj.injectedProp = 'injected'
-
-      return obj.a + 1
-    })
-    inc()
-
-    expect(argumentHistory(fn)).toMatchInlineSnapshot(`Array []`)
-  })
-
   test('combine + map', () => {
     const fn = jest.fn()
     const inc = createEvent()
     const $a = createStore(0).on(inc, x => x + 1)
     const $b = createStore(0).on(inc, x => x + 1)
     const combined = combine([$a, $b]).map((array: any) => {
-      if (array[2] === 'injected') {
-        fn(array[2])
-      }
-      array[2] = 'injected'
       const mainSlice = array.slice
       array.slice = (...args: any[]) => {
         fn('slice')

--- a/src/effector/combine.ts
+++ b/src/effector/combine.ts
@@ -125,6 +125,9 @@ const storeCombination = (
     mov({store: isFresh, to: 'b'}),
     calc((upd, {key}, reg) => {
       if (reg.c || upd !== reg.a[key]) {
+        if (needSpread && reg.b) {
+          reg.a = clone(reg.a)
+        }
         reg.a[key] = upd
         return true
       }

--- a/src/effector/combine.ts
+++ b/src/effector/combine.ts
@@ -83,12 +83,12 @@ const storeCombination = (
   needSpread: boolean,
   obj: any,
   config?: Config,
-  fn?: (upd: any) => any,
+  fn: (upd: any) => any = defaultFn,
 ) => {
   const clone = isArray ? (list: any) => list.slice() : (obj: any) => ({...obj})
   const defaultState: Record<string, any> = isArray ? [] : {}
 
-  if (fn && needSpread) {
+  if (needSpread) {
     const handler = fn
     fn = (list: any[]) => handler(clone(list))
   }
@@ -142,7 +142,7 @@ const storeCombination = (
       batch: true,
     }),
     read(rawShape, true),
-    fn && userFnCall(),
+    userFnCall(),
   ]
   forIn(obj, (child: Store<any> | any, key) => {
     if (!is.store(child)) {
@@ -179,4 +179,8 @@ const storeCombination = (
 export function createStoreObject(...args: any[]) {
   deprecate(false, 'createStoreObject', 'combine')
   return combine(...args)
+}
+
+function defaultFn(x: any) {
+  return x
 }

--- a/src/effector/combine.ts
+++ b/src/effector/combine.ts
@@ -83,15 +83,10 @@ const storeCombination = (
   needSpread: boolean,
   obj: any,
   config?: Config,
-  fn: (upd: any) => any = defaultFn,
+  fn?: (upd: any) => any,
 ) => {
   const clone = isArray ? (list: any) => [...list] : (obj: any) => ({...obj})
   const defaultState: Record<string, any> = isArray ? [] : {}
-
-  if (needSpread) {
-    const handler = fn
-    fn = (list: any[]) => handler(clone(list))
-  }
 
   const stateNew = clone(defaultState)
   const rawShape = createStateRef(stateNew)
@@ -142,7 +137,7 @@ const storeCombination = (
       batch: true,
     }),
     read(rawShape, true),
-    userFnCall(),
+    fn && userFnCall(),
   ]
   forIn(obj, (child: Store<any> | any, key) => {
     if (!is.store(child)) {
@@ -179,8 +174,4 @@ const storeCombination = (
 export function createStoreObject(...args: any[]) {
   deprecate(false, 'createStoreObject', 'combine')
   return combine(...args)
-}
-
-function defaultFn(x: any) {
-  return x
 }

--- a/src/effector/combine.ts
+++ b/src/effector/combine.ts
@@ -85,7 +85,7 @@ const storeCombination = (
   config?: Config,
   fn: (upd: any) => any = defaultFn,
 ) => {
-  const clone = isArray ? (list: any) => list.slice() : (obj: any) => ({...obj})
+  const clone = isArray ? (list: any) => [...list] : (obj: any) => ({...obj})
   const defaultState: Record<string, any> = isArray ? [] : {}
 
   if (needSpread) {

--- a/src/effector/combine.ts
+++ b/src/effector/combine.ts
@@ -88,6 +88,11 @@ const storeCombination = (
   const clone = isArray ? (list: any) => list.slice() : (obj: any) => ({...obj})
   const defaultState: Record<string, any> = isArray ? [] : {}
 
+  if (fn && needSpread) {
+    const handler = fn
+    fn = (list: any[]) => handler(clone(list))
+  }
+
   const stateNew = clone(defaultState)
   const rawShape = createStateRef(stateNew)
   const isFresh = createStateRef(true)
@@ -120,9 +125,6 @@ const storeCombination = (
     mov({store: isFresh, to: 'b'}),
     calc((upd, {key}, reg) => {
       if (reg.c || upd !== reg.a[key]) {
-        if (needSpread && reg.b) {
-          reg.a = clone(reg.a)
-        }
         reg.a[key] = upd
         return true
       }


### PR DESCRIPTION
Effector uses Array.slice internally to prepare argument object for a user, there is a case, where it was broken

Changelog:
- Added tests against breaking `combine` argument in userland via `.slice = undefined` or similiar code
- Changed `arr.slice()` to `[...arr]`