### PR TITLE
Support `fork(scope)` edge cases

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -3095,7 +3095,7 @@ export function fork(config?: {
 export function allSettled<FX extends Effect<any, any, any>>(
   unit: FX,
   config: {scope: Scope; params: EffectParams<FX>},
-): Promise<{status: 'done', value: EffectResult<FX>} | {status: 'fail'; value: EffectError<FX>}>
+): Promise<{status: 'done', value: EffectResult<FX>} | {status: 'fail'; value: EffectError<FX>} | {status: 'forked'}>
 /**
  * Run effect withot arguments in scope and wait for all triggered effects to settle. This method never throw an error
  * @param unit effect to run
@@ -3104,7 +3104,7 @@ export function allSettled<FX extends Effect<any, any, any>>(
 export function allSettled<FX extends Effect<void, any, any>>(
   unit: FX,
   config: {scope: Scope},
-): Promise<{status: 'done', value: EffectResult<FX>} | {status: 'fail'; value: EffectError<FX>}>
+): Promise<{status: 'done', value: EffectResult<FX>} | {status: 'fail'; value: EffectError<FX>} | {status: 'forked'}>
 /**
  * Run unit in scope and wait for all triggered effects to settle. This method never throw an error
  * @param unit event or store to run
@@ -3113,7 +3113,7 @@ export function allSettled<FX extends Effect<void, any, any>>(
 export function allSettled<T>(
   unit: Unit<T>,
   config: {scope: Scope; params: T},
-): Promise<void>
+): Promise<void | {status: 'forked'}>
 /**
  * Run unit without arguments in scope and wait for all triggered effects to settle. This method never throw an error
  * @param unit event or store to run
@@ -3122,7 +3122,7 @@ export function allSettled<T>(
 export function allSettled(
   unit: Unit<void>,
   config: {scope: Scope},
-): Promise<void>
+): Promise<void | {status: 'forked'}>
 
 export function createWatch<T>({
   unit,

--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -3001,6 +3001,7 @@ export function combine<T extends Tuple<Store<any>>>(
  * Fully isolated instance of application. The primary purpose of scope includes SSR and testing
  */
 export interface Scope extends Unit<any> {
+  live: boolean;
   getState<T>(store: Store<T>): T
 }
 

--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -3047,7 +3047,30 @@ export function fork(
   domain: Domain,
   config?: {
     values?: ValueMap
-    handlers?: Map<Effect<any, any, any>, Function> | Array<[Effect<any, any>, Function]> | {[sid: string]: Function}
+    handlers?:
+      | Map<Effect<any, any, any>, Function>
+      | Array<[Effect<any, any>, Function]>
+      | {[sid: string]: Function}
+  },
+): Scope
+/**
+ * Creates isolated instance of application. Primary purposes of this method are SSR and testing.
+ *
+ * Fork of old scope will move state and ownership of all effects and scopeBind functions to a new scope.
+ * Old scope will be disabled
+ *
+ * @param domain optional scope to fork
+ * @param config optional configuration object with initial store values and effect handlers
+ * @returns new scope
+ */
+export function fork(
+  scope: Scope,
+  config?: {
+    values?: ValueMap
+    handlers?:
+      | Map<Effect<any, any, any>, Function>
+      | Array<[Effect<any, any>, Function]>
+      | {[sid: string]: Function}
   },
 ): Scope
 /**
@@ -3055,12 +3078,13 @@ export function fork(
  * @param config optional configuration object with initial store values and effect handlers
  * @returns new scope
  */
-export function fork(
-  config?: {
-    values?: ValueMap
-    handlers?: Map<Effect<any, any, any>, Function> | Array<[Effect<any, any>, Function]> | {[sid: string]: Function}
-  },
-): Scope
+export function fork(config?: {
+  values?: ValueMap
+  handlers?:
+    | Map<Effect<any, any, any>, Function>
+    | Array<[Effect<any, any>, Function]>
+    | {[sid: string]: Function}
+}): Scope
 
 /**
  * Run effect in scope and wait for all triggered effects to settle. This method never throw an error

--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -3001,7 +3001,7 @@ export function combine<T extends Tuple<Store<any>>>(
  * Fully isolated instance of application. The primary purpose of scope includes SSR and testing
  */
 export interface Scope extends Unit<any> {
-  live: boolean;
+  alive: boolean;
   getState<T>(store: Store<T>): T
 }
 

--- a/src/effector/__tests__/fork/fork.test.ts
+++ b/src/effector/__tests__/fork/fork.test.ts
@@ -1033,12 +1033,12 @@ describe('fork another scope', () => {
       `"createWatch cannot be called on a dead scope"`,
     )
   })
-})
 
-test('Live scope can be distinguished from the forked one', () => {
-  const scope = fork()
-  const newScope = fork(scope)
+  test('Live scope can be distinguished from the forked one', () => {
+    const scope = fork()
+    const newScope = fork(scope)
 
-  expect(scope.live).toEqual(false)
-  expect(newScope.live).toEqual(true)
+    expect(scope.live).toEqual(false)
+    expect(newScope.live).toEqual(true)
+  })
 })

--- a/src/effector/__tests__/fork/fork.test.ts
+++ b/src/effector/__tests__/fork/fork.test.ts
@@ -794,7 +794,7 @@ describe('fork another scope', () => {
     expect(oldScope.getState($b)).toEqual(newScope.getState($b))
   })
 
-  test.skip('new scope allows to add new values on top of old ones', async () => {
+  test('new scope allows to add new values on top of old ones', async () => {
     const changeValues = createEvent<{a: number; b: number}>()
     const $a = createStore(0, {sid: '$a'}).on(changeValues, (_, {a}) => a)
     const $b = createStore(0).on(changeValues, (_, {b}) => b)
@@ -812,8 +812,9 @@ describe('fork another scope', () => {
     const oldState = serialize(oldScope)
     const newState = serialize(newScope)
 
-    expect(oldState).toEqual(newState)
+    expect(oldState).not.toEqual(newState)
     expect(oldScope.getState($b)).toEqual(newScope.getState($b))
+    expect(oldScope.getState($a)).toEqual(1)
     expect(newScope.getState($a)).toEqual(3)
   })
 

--- a/src/effector/__tests__/fork/fork.test.ts
+++ b/src/effector/__tests__/fork/fork.test.ts
@@ -1026,3 +1026,11 @@ describe('fork another scope', () => {
     }).toThrow()
   })
 })
+
+test('Live scope can be distinguished from the forked one', () => {
+  const scope = fork();
+  const newScope = fork(scope);
+
+  expect(scope.live).toEqual(false);
+  expect(newScope.live).toEqual(true);
+})

--- a/src/effector/__tests__/fork/fork.test.ts
+++ b/src/effector/__tests__/fork/fork.test.ts
@@ -1001,7 +1001,7 @@ describe('fork another scope', () => {
     expect(watch).toBeCalledTimes(1)
     expect(argumentHistory(watch)).toEqual(['a'])
 
-    const scopeB = fork({
+    const scopeB = fork(scopeA, {
       values: [[$source, 'b']],
     })
 

--- a/src/effector/__tests__/fork/fork.test.ts
+++ b/src/effector/__tests__/fork/fork.test.ts
@@ -913,7 +913,9 @@ describe('fork another scope', () => {
     }).not.toThrow()
     expect(() => {
       scopeBind(event, {scope})
-    }).toThrow()
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"scopeBind cannot be called on dead scope"`,
+    )
   })
 
   test('new scope owns running effects of the old one', async () => {
@@ -955,22 +957,26 @@ describe('fork another scope', () => {
     }).not.toThrow()
     expect(() => {
       allSettled(event, {scope})
-    }).toThrow()
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"allSettled cannot be called on dead scope"`,
+    )
   })
 
   test('allSettled of the old scope is immediatly resolved after fork', async () => {
-    const fx = createEffect(async () => await new Promise(r => setTimeout(r, 10)))
+    const fx = createEffect(
+      async () => await new Promise(r => setTimeout(r, 10)),
+    )
 
     const scope = fork()
 
-    const promise = allSettled(fx, {scope});
+    const promise = allSettled(fx, {scope})
 
-    fork(scope);
+    fork(scope)
 
-    const final = await promise;
+    const final = await promise
 
     expect(final).toEqual({
-      status: "forked"
+      status: 'forked',
     })
   })
 
@@ -1023,14 +1029,16 @@ describe('fork another scope', () => {
         scope,
         fn: () => {},
       })
-    }).toThrow()
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"createWatch cannot be called on a dead scope"`,
+    )
   })
 })
 
 test('Live scope can be distinguished from the forked one', () => {
-  const scope = fork();
-  const newScope = fork(scope);
+  const scope = fork()
+  const newScope = fork(scope)
 
-  expect(scope.live).toEqual(false);
-  expect(newScope.live).toEqual(true);
+  expect(scope.live).toEqual(false)
+  expect(newScope.live).toEqual(true)
 })

--- a/src/effector/__tests__/fork/fork.test.ts
+++ b/src/effector/__tests__/fork/fork.test.ts
@@ -1034,12 +1034,12 @@ describe('fork another scope', () => {
     )
   })
 
-  test('Live scope can be distinguished from the forked one', () => {
+  test('Alive scope can be distinguished from the forked one', () => {
     const scope = fork()
     const newScope = fork(scope)
 
-    expect(scope.live).toEqual(false)
-    expect(newScope.live).toEqual(true)
+    expect(scope.alive).toEqual(false)
+    expect(newScope.alive).toEqual(true)
   })
 
   test('edge case: scopeBind inside effect catches correct scope', async () => {

--- a/src/effector/__tests__/fork/fork.test.ts
+++ b/src/effector/__tests__/fork/fork.test.ts
@@ -958,7 +958,21 @@ describe('fork another scope', () => {
     }).toThrow()
   })
 
-  test.todo('allSettled of the old scope is immediatly resolved after fork')
+  test('allSettled of the old scope is immediatly resolved after fork', async () => {
+    const fx = createEffect(async () => await new Promise(r => setTimeout(r, 10)))
+
+    const scope = fork()
+
+    const promise = allSettled(fx, {scope});
+
+    fork(scope);
+
+    const final = await promise;
+
+    expect(final).toEqual({
+      status: "forked"
+    })
+  })
 
   test('new scope owns createWatch of the old scope', async () => {
     const $source = createStore('a')

--- a/src/effector/attach.ts
+++ b/src/effector/attach.ts
@@ -1,6 +1,6 @@
 import type {Domain} from './unit.h'
 import {combine} from './combine'
-import {createEffect, createScopeRef, onSettled, runFn} from './createEffect'
+import {createEffect, getScopeRef, onSettled, runFn} from './createEffect'
 import {applyParentHook} from './createUnit'
 import {processArgsToConfig} from './config'
 import {
@@ -29,7 +29,7 @@ export function attach(config: any) {
     (upd, _, stack) => {
       const {params, req, handler} = upd
       const anyway = attached.finally
-      const scopeRef = createScopeRef(stack)
+      const scopeRef = getScopeRef(stack)
       const rj = onSettled(params, req, false, anyway, stack, scopeRef)
       const sourceData = stack.a
       const isEffectHandler = is.effect(handler)

--- a/src/effector/createEffect.ts
+++ b/src/effector/createEffect.ts
@@ -120,7 +120,7 @@ export function createEffect<Params, Done, Fail = Error>(
           _,
           stack,
         ) => {
-          const scopeRef = createScopeRef(stack)
+          const scopeRef = getScopeRef(stack)
           const onResolve = onSettled(
             params,
             req,
@@ -230,10 +230,10 @@ export const runFn = (
   }
 }
 
-export const createScopeRef = (stack: Stack) => {
+export const getScopeRef = (stack: Stack) => {
   const scope = getForkPage(stack)
-  const scopeRef = {ref: scope}
-  if (scope) add(scope.activeEffects, scopeRef)
+  const scopeRef = scope?.scopeRef ?? {ref: undefined as void}
+
   return scopeRef
 }
 
@@ -250,7 +250,6 @@ export const onSettled =
     scopeRef: {ref: Scope | void},
   ) =>
   (data: any) => {
-    if (scopeRef.ref) removeItem(scopeRef.ref.activeEffects, scopeRef)
     launch({
       target: [anyway, sidechain],
       params: [

--- a/src/effector/createWatch.ts
+++ b/src/effector/createWatch.ts
@@ -1,5 +1,6 @@
 import {clearNode} from './clearNode'
 import {createNode} from './createNode'
+import {assert} from './throw'
 import type {Node, Subscription, Unit} from './index.h'
 import {step} from './step'
 import {Scope} from './unit.h'
@@ -15,6 +16,7 @@ export function createWatch<T>({
 }): Subscription {
   const seq = [step.run({fn: value => fn(value)})]
   if (scope) {
+    assert(scope.live, 'createWatch cannot be called on a dead scope')
     const node = createNode({node: seq})
     const id = (unit as any).graphite.id
     const scopeLinks: {[_: string]: Node[]} = (scope as any).additionalLinks

--- a/src/effector/createWatch.ts
+++ b/src/effector/createWatch.ts
@@ -16,7 +16,7 @@ export function createWatch<T>({
 }): Subscription {
   const seq = [step.run({fn: value => fn(value)})]
   if (scope) {
-    assert(scope.live, 'createWatch cannot be called on a dead scope')
+    assert(scope.alive, 'createWatch cannot be called on a dead scope')
     const node = createNode({node: seq})
     const id = (unit as any).graphite.id
     const scopeLinks: {[_: string]: Node[]} = (scope as any).additionalLinks

--- a/src/effector/fork/allSettled.ts
+++ b/src/effector/fork/allSettled.ts
@@ -1,5 +1,6 @@
 import {add} from '../collection'
 import {createDefer} from '../defer'
+import {assert} from '../throw'
 import {is} from '../is'
 import {launch, forkPage} from '../kernel'
 import type {Scope, Event, Effect, DataCarrier, SettledDefer} from '../unit.h'
@@ -14,6 +15,9 @@ export function allSettled<T>(
     return Promise.reject(
       new Error('first argument accepts only effects, events and stores'),
     )
+  assert(scope, 'scope is required')
+  assert(scope.live, 'allSettled cannot be called on dead scope')
+
   const defer = createDefer() as SettledDefer
   defer.parentFork = forkPage
   const {fxCount} = scope

--- a/src/effector/fork/allSettled.ts
+++ b/src/effector/fork/allSettled.ts
@@ -16,7 +16,7 @@ export function allSettled<T>(
       new Error('first argument accepts only effects, events and stores'),
     )
   assert(scope, 'scope is required')
-  assert(scope.live, 'allSettled cannot be called on dead scope')
+  assert(scope.alive, 'allSettled cannot be called on dead scope')
 
   const defer = createDefer() as SettledDefer
   defer.parentFork = forkPage

--- a/src/effector/fork/createScope.ts
+++ b/src/effector/fork/createScope.ts
@@ -144,7 +144,7 @@ export function createScope(baseUnit?: Domain | Scope): Scope {
     resultScope.scopeRef = oldScope.scopeRef
 
     // transfer old scope state to the new one
-    resultScope.sidValuesMap = Object.assign({}, oldScope.sidValuesMap)
+    resultScope.sidValuesMap = {...oldScope.sidValuesMap}
     resultScope.sidSerializeMap = oldScope.sidSerializeMap
 
     // transfer old scope handlers to the new one

--- a/src/effector/fork/createScope.ts
+++ b/src/effector/fork/createScope.ts
@@ -127,7 +127,8 @@ export function createScope(unit?: Domain): Scope {
     fxCount: forkInFlightCounter,
     storeChange,
     warnSerializeNode,
-    activeEffects: [],
+    scopeRef: {ref: null as unknown as Scope},
   }
+  resultScope.scopeRef.ref = resultScope
   return resultScope
 }

--- a/src/effector/fork/createScope.ts
+++ b/src/effector/fork/createScope.ts
@@ -101,6 +101,7 @@ export function createScope(baseUnit?: Domain | Scope): Scope {
     ],
   })
   const resultScope: Scope = {
+    live: true,
     cloneOf: is.domain(baseUnit) ? baseUnit : undefined,
     reg: page,
     sidValuesMap: {},
@@ -152,6 +153,9 @@ export function createScope(baseUnit?: Domain | Scope): Scope {
 
     // transfer old scope additionalLinks to the new one
     resultScope.additionalLinks = oldScope.additionalLinks
+
+    // mark old scope as not "live" anymore
+    oldScope.live = false
   }
 
   return resultScope

--- a/src/effector/fork/createScope.ts
+++ b/src/effector/fork/createScope.ts
@@ -145,7 +145,6 @@ export function createScope(baseUnit?: Domain | Scope): Scope {
 
     // transfer old scope state to the new one
     resultScope.sidValuesMap = Object.assign({}, oldScope.sidValuesMap)
-    resultScope.sidIdMap = oldScope.sidIdMap
     resultScope.sidSerializeMap = oldScope.sidSerializeMap
 
     // transfer old scope handlers to the new one
@@ -153,12 +152,6 @@ export function createScope(baseUnit?: Domain | Scope): Scope {
 
     // transfer old scope additionalLinks to the new one
     resultScope.additionalLinks = oldScope.additionalLinks
-
-    // transfer old reg to the new one
-    resultScope.reg = {}
-    for (const key in oldScope.reg) {
-      resultScope.reg[key] = {...oldScope.reg[key]}
-    }
   }
 
   return resultScope

--- a/src/effector/fork/createScope.ts
+++ b/src/effector/fork/createScope.ts
@@ -153,6 +153,7 @@ export function createScope(baseUnit?: Domain | Scope): Scope {
 
     // transfer old scope additionalLinks to the new one
     resultScope.additionalLinks = oldScope.additionalLinks
+    oldScope.additionalLinks = {}
 
     // mark old scope as not "live" anymore
     oldScope.live = false

--- a/src/effector/fork/createScope.ts
+++ b/src/effector/fork/createScope.ts
@@ -98,7 +98,7 @@ export function createScope(baseUnit?: Domain | Scope): Scope {
     ],
   })
   const resultScope: Scope = {
-    live: true,
+    alive: true,
     cloneOf: is.domain(baseUnit) ? baseUnit : undefined,
     reg: page,
     sidValuesMap: {},
@@ -152,8 +152,8 @@ export function createScope(baseUnit?: Domain | Scope): Scope {
     resultScope.additionalLinks = oldScope.additionalLinks
     oldScope.additionalLinks = {}
 
-    // mark old scope as not "live" anymore
-    oldScope.live = false
+    // mark old scope as not "alive" anymore
+    oldScope.alive = false
 
     // resolve all allSettled calls of old scope
     resolveDefers(oldScope.fxCount.scope.defers, {status: 'forked'})

--- a/src/effector/fork/fork.ts
+++ b/src/effector/fork/fork.ts
@@ -1,5 +1,5 @@
 import {is} from '../is'
-import {assert} from '../throw'
+import {assert, deprecate} from '../throw'
 import type {Domain, ValuesMap, HandlersMap, Scope} from '../unit.h'
 import {normalizeValues} from './util'
 import {createScope} from './createScope'
@@ -20,6 +20,8 @@ export function fork(
   let config: ForkConfig | undefined = hasTarget
     ? optionalConfig
     : targetOrConfig
+
+  deprecate(!is.domain(target), 'fork(domain)', 'fork()')
 
   const scope = createScope(target)
 

--- a/src/effector/fork/fork.ts
+++ b/src/effector/fork/fork.ts
@@ -27,10 +27,13 @@ export function fork(
   if (config) {
     const oldScope = config.scope
     if (oldScope) {
-      const activeEffects = oldScope.activeEffects
-      oldScope.activeEffects = []
-      scope.activeEffects = activeEffects
-      forEach(activeEffects, scopeRef => (scopeRef.ref = scope))
+      // Update old scope scopeRef
+      // to redirect all effect.finally and scope-binded events to new scope
+      oldScope.scopeRef.ref = scope
+
+      // transfer old scope scopeRef to the new scope,
+      // so any further fork(scope) calls will also redirect any effect.finally and scope-binded events to new scope
+      scope.scopeRef = oldScope.scopeRef
     }
     if (config.values) {
       const valuesSidMap = normalizeValues(config.values, unit =>

--- a/src/effector/fork/fork.ts
+++ b/src/effector/fork/fork.ts
@@ -21,7 +21,8 @@ export function fork(
     ? optionalConfig
     : targetOrConfig
 
-  deprecate(!is.domain(target), 'fork(domain)', 'fork()')
+  // TODO: deprecate once major release is ready
+  // deprecate(!is.domain(target), 'fork(domain)', 'fork()')
 
   const scope = createScope(target)
 

--- a/src/effector/fork/fork.ts
+++ b/src/effector/fork/fork.ts
@@ -3,54 +3,44 @@ import {assert} from '../throw'
 import type {Domain, ValuesMap, HandlersMap, Scope} from '../unit.h'
 import {normalizeValues} from './util'
 import {createScope} from './createScope'
-import {forEach} from '../collection'
 
 type ForkConfig = {
   values?: ValuesMap
   handlers?: HandlersMap
-  scope?: Scope
 }
 
 export function fork(
-  domainOrConfig?: Domain | ForkConfig,
-  optiionalConfig?: ForkConfig,
+  targetOrConfig?: Domain | ForkConfig | Scope,
+  optionalConfig?: ForkConfig,
 ) {
-  let config: ForkConfig | void = domainOrConfig as any
-  let domain: Domain
-  if (is.domain(domainOrConfig)) {
-    domain = domainOrConfig
-    config = optiionalConfig
+  const hasTarget = is.unit(targetOrConfig)
+  let target: Domain | Scope | undefined = hasTarget
+    ? targetOrConfig
+    : undefined
+  let config: ForkConfig | undefined = hasTarget
+    ? optionalConfig
+    : targetOrConfig
+
+  const scope = createScope(target)
+
+  if (config?.values) {
+    const valuesSidMap = normalizeValues(config.values, unit =>
+      assert(is.store(unit), 'Values map can contain only stores as keys'),
+    )
+    Object.assign(scope.sidValuesMap, valuesSidMap)
+    scope.fromSerialize =
+      !Array.isArray(config.values) && !(config.values instanceof Map)
   }
-
-  const scope = createScope(domain!)
-
-  if (config) {
-    const oldScope = config.scope
-    if (oldScope) {
-      // Update old scope scopeRef
-      // to redirect all effect.finally and scope-binded events to new scope
-      oldScope.scopeRef.ref = scope
-
-      // transfer old scope scopeRef to the new scope,
-      // so any further fork(scope) calls will also redirect any effect.finally and scope-binded events to new scope
-      scope.scopeRef = oldScope.scopeRef
-    }
-    if (config.values) {
-      const valuesSidMap = normalizeValues(config.values, unit =>
-        assert(is.store(unit), 'Values map can contain only stores as keys'),
-      )
-      Object.assign(scope.sidValuesMap, valuesSidMap)
-      scope.fromSerialize =
-        !Array.isArray(config.values) && !(config.values instanceof Map)
-    }
-    if (config.handlers) {
-      scope.handlers = normalizeValues(config.handlers, unit =>
+  if (config?.handlers) {
+    Object.assign(
+      scope.handlers,
+      normalizeValues(config.handlers, unit =>
         assert(
           is.effect(unit),
           `Handlers map can contain only effects as keys`,
         ),
-      )
-    }
+      ),
+    )
   }
   return scope
 }

--- a/src/effector/fork/hydrate.ts
+++ b/src/effector/fork/hydrate.ts
@@ -17,7 +17,8 @@ import {getGraph, getMeta} from '../getter'
 
  */
 export function hydrate(domain: Domain | Scope, {values}: {values: ValuesMap}) {
-  deprecate(true, 'hydrate', 'Fork API')
+  // TODO: deprecate once major release is ready
+  // deprecate(true, 'hydrate', 'Fork API')
   assert(isObject(values), 'values property should be an object')
   const normalizedValues = normalizeValues(values)
   const valuesSidList = Object.getOwnPropertyNames(normalizedValues)

--- a/src/effector/fork/hydrate.ts
+++ b/src/effector/fork/hydrate.ts
@@ -1,5 +1,5 @@
 import {is, isObject} from '../is'
-import {assert} from '../throw'
+import {assert, deprecate} from '../throw'
 import {launch} from '../kernel'
 import type {Domain, Scope, ValuesMap} from '../unit.h'
 import type {Node} from '../index.h'
@@ -17,6 +17,7 @@ import {getGraph, getMeta} from '../getter'
 
  */
 export function hydrate(domain: Domain | Scope, {values}: {values: ValuesMap}) {
+  deprecate(true, 'hydrate', 'Fork API')
   assert(isObject(values), 'values property should be an object')
   const normalizedValues = normalizeValues(values)
   const valuesSidList = Object.getOwnPropertyNames(normalizedValues)

--- a/src/effector/fork/scopeBind.ts
+++ b/src/effector/fork/scopeBind.ts
@@ -16,7 +16,7 @@ export function scopeBind(
   )
   const forkRoot = scope || forkPage;
 
-  assert(!forkRoot || forkRoot.live, 'scopeBind cannot be called on dead scope')
+  assert(!forkRoot || forkRoot.alive, 'scopeBind cannot be called on dead scope')
 
   const savedScopeRef = forkRoot?.scopeRef
   return is.effect(unit)

--- a/src/effector/fork/scopeBind.ts
+++ b/src/effector/fork/scopeBind.ts
@@ -14,7 +14,7 @@ export function scopeBind(
     scope || forkPage || safe,
     'scopeBind cannot be called outside of forked .watch',
   )
-  const savedForkPage = scope || forkPage!
+  const savedScopeRef = (scope || forkPage)!.scopeRef
   return is.effect(unit)
     ? (params: any) => {
         const req = createDefer()
@@ -24,12 +24,12 @@ export function scopeBind(
             params,
             req,
           },
-          scope: savedForkPage,
+          scope: savedScopeRef.ref,
         })
         return req.req
       }
     : (params: any) => {
-        launch({target: unit, params, scope: savedForkPage})
+        launch({target: unit, params, scope: savedScopeRef.ref})
         return params
       }
 }

--- a/src/effector/fork/scopeBind.ts
+++ b/src/effector/fork/scopeBind.ts
@@ -14,7 +14,11 @@ export function scopeBind(
     scope || forkPage || safe,
     'scopeBind cannot be called outside of forked .watch',
   )
-  const savedScopeRef = (scope || forkPage)?.scopeRef
+  const forkRoot = scope || forkPage;
+
+  assert(!forkRoot || forkRoot.live, 'scopeBind cannot be called on dead scope')
+
+  const savedScopeRef = forkRoot?.scopeRef
   return is.effect(unit)
     ? (params: any) => {
         const req = createDefer()

--- a/src/effector/fork/scopeBind.ts
+++ b/src/effector/fork/scopeBind.ts
@@ -14,7 +14,7 @@ export function scopeBind(
     scope || forkPage || safe,
     'scopeBind cannot be called outside of forked .watch',
   )
-  const savedScopeRef = (scope || forkPage)!.scopeRef
+  const savedScopeRef = (scope || forkPage)?.scopeRef
   return is.effect(unit)
     ? (params: any) => {
         const req = createDefer()
@@ -24,12 +24,12 @@ export function scopeBind(
             params,
             req,
           },
-          scope: savedScopeRef.ref,
+          scope: savedScopeRef?.ref,
         })
         return req.req
       }
     : (params: any) => {
-        launch({target: unit, params, scope: savedScopeRef.ref})
+        launch({target: unit, params, scope: savedScopeRef?.ref})
         return params
       }
 }

--- a/src/effector/getter.ts
+++ b/src/effector/getter.ts
@@ -9,7 +9,7 @@ export const getStoreState = (store: Store<any>): StateRef => store.stateRef
 export const getValue = (stack: any) => stack.value
 export const getSubscribers = (store: Store<any>) => store.subscribers
 export const getParent = (unit: any) => unit.parent
-export const getForkPage = (val: any): Scope | void => val.scope
+export const getForkPage = (val: any): Scope | void => val.scope?.scopeRef.ref
 export const getMeta = (unit: NodeUnit, field: string) =>
   getGraph(unit).meta[field]
 export const setMeta = (unit: NodeUnit, field: string, value: unknown) =>

--- a/src/effector/kernel.ts
+++ b/src/effector/kernel.ts
@@ -194,7 +194,7 @@ export let isPure = false
 export let currentPage: Leaf | null = null
 export let forkPage: Scope | void | null
 export const setForkPage = (newForkPage: Scope | void | null) => {
-  forkPage = newForkPage
+  forkPage = newForkPage?.scopeRef.ref
 }
 export const setCurrentPage = (newPage: Leaf | null) => {
   currentPage = newPage

--- a/src/effector/unit.h.ts
+++ b/src/effector/unit.h.ts
@@ -164,6 +164,7 @@ export interface Domain extends Unit {
 }
 
 export interface Scope extends Unit {
+  live: boolean;
   fromSerialize?: boolean
   kind: Kind
   graphite: Node

--- a/src/effector/unit.h.ts
+++ b/src/effector/unit.h.ts
@@ -182,7 +182,7 @@ export interface Scope extends Unit {
   /** if any affected store is missing sid, then scope cannot be serialized correctly and data will be missing */
   warnSerialize?: boolean
   warnSerializeNode: Node
-  activeEffects: Array<{ref: Scope}>
+  scopeRef: {ref: Scope}
 }
 
 export type CommonUnit<T = any> = Event<T> | Effect<T, any, any> | Store<T>

--- a/src/effector/unit.h.ts
+++ b/src/effector/unit.h.ts
@@ -164,7 +164,7 @@ export interface Domain extends Unit {
 }
 
 export interface Scope extends Unit {
-  live: boolean;
+  alive: boolean;
   fromSerialize?: boolean
   kind: Kind
   graphite: Node

--- a/src/types/__tests__/effector/fork.test.ts
+++ b/src/types/__tests__/effector/fork.test.ts
@@ -212,7 +212,7 @@ describe('allSettled', () => {
   test('event', () => {
     const app = createDomain()
     const event = app.createEvent<number>()
-    const req: Promise<void> = allSettled(event, {
+    const req: Promise<void | {status: 'forked'}> = allSettled(event, {
       scope: fork(app),
       params: 0,
     })
@@ -225,7 +225,7 @@ describe('allSettled', () => {
   test('void event', () => {
     const app = createDomain()
     const event = app.createEvent()
-    const req: Promise<void> = allSettled(event, {
+    const req: Promise<void | {status: 'forked'}> = allSettled(event, {
       scope: fork(app),
     })
     expect(typecheck).toMatchInlineSnapshot(`
@@ -238,7 +238,7 @@ describe('allSettled', () => {
     const app = createDomain()
     const fx = app.createEffect((x: number) => x.toString())
     const req: Promise<
-      {status: 'done'; value: string} | {status: 'fail'; value: Error}
+      {status: 'done'; value: string} | {status: 'fail'; value: Error} | {status: 'forked'}
     > = allSettled(fx, {
       scope: fork(app),
       params: 0,
@@ -253,7 +253,7 @@ describe('allSettled', () => {
     const app = createDomain()
     const fx = app.createEffect(() => 'ok')
     const req: Promise<
-      {status: 'done'; value: string} | {status: 'fail'; value: Error}
+      {status: 'done'; value: string} | {status: 'fail'; value: Error} | {status: 'forked'}
     > = allSettled(fx, {
       scope: fork(app),
     })


### PR DESCRIPTION
There is a potential breaking change at the types level - now all settled will return special `{ status: 'forked' }` object, if scope was forked during allSettled run

Typescript will force user to explicitly handle this new case