### PR TITLE
Separate warning message for reset derived store

### DIFF
--- a/src/effector/__tests__/derived.test.ts
+++ b/src/effector/__tests__/derived.test.ts
@@ -139,7 +139,7 @@ test('createApi', () => {
   const $derived = $a.map(x => x)
   createApi($derived, {x: () => 0})
   expect(getWarning()).toMatchInlineSnapshot(
-    `".on in derived store is deprecated, use createStore instead"`,
+    `".on in derived store is deprecated, use .on in store created via createStore instead"`,
   )
 })
 

--- a/src/effector/__tests__/derived.test.ts
+++ b/src/effector/__tests__/derived.test.ts
@@ -143,23 +143,41 @@ test('createApi', () => {
   )
 })
 
-describe('.on with derived stores', () => {
-  test('usage with .map is deprecated', () => {
+describe('.on/.reset with derived stores', () => {
+  test('.on usage with .map is deprecated', () => {
     const trigger = createEvent()
     const $a = createStore(0)
     const $b = $a.map(x => x)
     $b.on(trigger, x => x)
     expect(getWarning()).toMatchInlineSnapshot(
-      `".on in derived store is deprecated, use createStore instead"`,
+      `".on in derived store is deprecated, use .on in store created via createStore instead"`,
     )
   })
-  test('usage with combine is deprecated', () => {
+  test('.reset usage with .map is deprecated', () => {
+    const trigger = createEvent()
+    const $a = createStore(0)
+    const $b = $a.map(x => x)
+    $b.reset(trigger, x => x)
+    expect(getWarning()).toMatchInlineSnapshot(
+      `".reset in derived store is deprecated, use .reset in store created via createStore instead"`,
+    )
+  })
+  test('.on usage with combine is deprecated', () => {
     const trigger = createEvent()
     const $a = createStore(0)
     const $b = combine({a: $a})
     $b.on(trigger, x => x)
     expect(getWarning()).toMatchInlineSnapshot(
-      `".on in derived store is deprecated, use createStore instead"`,
+      `".on in derived store is deprecated, use .on in store created via createStore instead"`,
+    )
+  })
+  test('.reset usage with combine is deprecated', () => {
+    const trigger = createEvent()
+    const $a = createStore(0)
+    const $b = combine({a: $a})
+    $b.reset(trigger, x => x)
+    expect(getWarning()).toMatchInlineSnapshot(
+      `".reset in derived store is deprecated, use .reset in store created via createStore instead"`,
     )
   })
   describe('internal stores', () => {

--- a/src/effector/__tests__/derived.test.ts
+++ b/src/effector/__tests__/derived.test.ts
@@ -157,7 +157,7 @@ describe('.on/.reset with derived stores', () => {
     const trigger = createEvent()
     const $a = createStore(0)
     const $b = $a.map(x => x)
-    $b.reset(trigger, x => x)
+    $b.reset(trigger)
     expect(getWarning()).toMatchInlineSnapshot(
       `".reset in derived store is deprecated, use .reset in store created via createStore instead"`,
     )
@@ -175,7 +175,7 @@ describe('.on/.reset with derived stores', () => {
     const trigger = createEvent()
     const $a = createStore(0)
     const $b = combine({a: $a})
-    $b.reset(trigger, x => x)
+    $b.reset(trigger)
     expect(getWarning()).toMatchInlineSnapshot(
       `".reset in derived store is deprecated, use .reset in store created via createStore instead"`,
     )
@@ -186,7 +186,7 @@ describe('.on/.reset with derived stores', () => {
       const fx = createEffect(() => {})
       fx.inFlight.on(trigger, s => s + 1)
       expect(getWarning()).toMatchInlineSnapshot(
-        `".on in derived store is deprecated, use createStore instead"`,
+        `".on in derived store is deprecated, use .on in store created via createStore instead"`,
       )
     })
   })

--- a/src/effector/createUnit.ts
+++ b/src/effector/createUnit.ts
@@ -251,7 +251,7 @@ export function createStore<State>(
         scope: forkPage!,
       }),
     reset(...units: CommonUnit[]) {
-      forEach(units, unit => on(store, '.on', unit, () => store.defaultState))
+      forEach(units, unit => on(store, '.reset', unit, () => store.defaultState))
       return store
     },
     on(nodeSet: CommonUnit | CommonUnit[], fn: Function) {

--- a/src/effector/createUnit.ts
+++ b/src/effector/createUnit.ts
@@ -255,7 +255,7 @@ export function createStore<State>(
       return store
     },
     on(nodeSet: CommonUnit | CommonUnit[], fn: Function) {
-      return on (store, '.on', nodeSet, fn)
+      return on(store, '.on', nodeSet, fn)
     },
     off(unit: CommonUnit) {
       const currentSubscription = getSubscribers(store).get(unit)


### PR DESCRIPTION
Made common function to pass methodName for reset and on separately

### Conventions
- [x] Please check your messages [against the guidelines](https://cbea.ms/git-commit/) if not, perform [interactive rebase](https://thoughtbot.com/blog/git-interactive-rebase-squash-amend-rewriting-history)
- [ ] [Link an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) your pull request closes or relates
