### PR TITLE
Forbid restore(event) and restore(effect) in types

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -911,6 +911,8 @@ export function restore<E>(event: Event<E>, defaultState: E): Store<E>
  * @param defaultState initial state of new store
  */
 export function restore<E>(event: Event<E>, defaultState: null): Store<E | null>
+export function restore<T extends Event<any>>(event: T): never
+export function restore<T extends Effect<any, any, any>>(effect: T): never
 export function restore<State extends {[key: string]: Store<any> | any}>(
   state: State,
 ): {

--- a/src/types/__tests__/effector/restore.test.ts
+++ b/src/types/__tests__/effector/restore.test.ts
@@ -120,4 +120,40 @@ describe('restore cases (should fail)', () => {
       "
     `)
   })
+  test('restore(Event<any>)', () => {
+    try {
+      const ev = createEvent<number>()
+
+      let restored = restore(ev)
+      let store: Store<number>
+
+      store = restored
+      //@ts-expect-error
+      restored = store
+    } catch (e) {}
+
+    expect(typecheck).toMatchInlineSnapshot(`
+      "
+      Type 'Store<number>' is not assignable to type 'never'.
+      "
+    `)
+  })
+  test('restore(Effect<any,number,Error>)', () => {
+    try {
+      const eff = createEffect<any, number, Error>()
+
+      let restored = restore(eff)
+      let store: Store<number>
+
+      store = restored
+      //@ts-expect-error
+      restored = store
+    } catch (e) {}
+
+    expect(typecheck).toMatchInlineSnapshot(`
+      "
+      Type 'Store<number>' is not assignable to type 'never'.
+      "
+    `)
+  })
 })


### PR DESCRIPTION
Calling `restore` with Event or Effect without second `defaultState` argument will fail with runtime error.
But typescript will not warn about it, so you can miss this until you actually run the code.
I tried to add some type guards against it.