### PR TITLE
`serialize: ignore` must ignore serialize event `fork({values})` is used

### DIFF
--- a/src/effector/__tests__/fork/serialize.test.ts
+++ b/src/effector/__tests__/fork/serialize.test.ts
@@ -69,6 +69,22 @@ test('serialize: ignore', async () => {
   expect(serialize(scope)).toEqual({b: 1})
 })
 
+test('serialize: ignore with fork(values)', async () => {
+  const inc = createEvent()
+  const $a = createStore(0, {sid: 'a', serialize: 'ignore'})
+  const $b = createStore(0, {sid: 'b'})
+  $a.on(inc, x => x + 1)
+  $b.on(inc, x => x + 1)
+
+  const scope = fork({
+    values: [[$a, 100]]
+  })
+
+  await allSettled(inc, {scope})
+
+  expect(serialize(scope)).toEqual({b: 1})
+})
+
 describe('serialize: custom', () => {
   test('base case', async () => {
     expect.assertions(4)

--- a/src/effector/createUnit.ts
+++ b/src/effector/createUnit.ts
@@ -193,7 +193,12 @@ export function createEvent<Payload = any>(
   }
   return finalEvent
 }
-function on(store: Store<State>, methodName: string, nodeSet: CommonUnit | CommonUnit[], fn: Function) {
+function on<State>(
+  store: Store<State>,
+  methodName: string,
+  nodeSet: CommonUnit | CommonUnit[],
+  fn: Function,
+) {
   assertNodeSet(nodeSet, methodName, 'first argument')
   assert(isFunction(fn), 'second argument should be a function')
   deprecate(
@@ -205,9 +210,7 @@ function on(store: Store<State>, methodName: string, nodeSet: CommonUnit | Commo
     store.off(trigger)
     getSubscribers(store).set(
       trigger,
-      createSubscription(
-        updateStore(trigger, store, 'on', callARegStack, fn),
-      ),
+      createSubscription(updateStore(trigger, store, 'on', callARegStack, fn)),
     )
   })
   return store
@@ -251,7 +254,9 @@ export function createStore<State>(
         scope: forkPage!,
       }),
     reset(...units: CommonUnit[]) {
-      forEach(units, unit => on(store, '.reset', unit, () => store.defaultState))
+      forEach(units, unit =>
+        on(store, '.reset', unit, () => store.defaultState),
+      )
       return store
     },
     on(nodeSet: CommonUnit | CommonUnit[], fn: Function) {
@@ -341,7 +346,7 @@ export function createStore<State>(
   const customSerialize = !serializeMeta || ignored ? false : serializeMeta
   const sid: string | null = getMeta(store, 'sid')
   if (sid) {
-    if (!ignored) setMeta(store, 'storeChange', true)
+    setMeta(store, 'storeChange', true)
     plainState.sid = sid
 
     if (customSerialize) {

--- a/src/effector/fork/createScope.ts
+++ b/src/effector/fork/createScope.ts
@@ -124,7 +124,7 @@ export function createScope(unit?: Domain): Scope {
     graphite: createNode({
       family: {
         type: DOMAIN,
-        links: [storeChange, forkInFlightCounter, warnSerializeNode],
+        links: [forkInFlightCounter, storeChange, warnSerializeNode],
       },
       meta: {unit: 'fork'},
       scope: {forkInFlightCounter},

--- a/src/effector/fork/createScope.ts
+++ b/src/effector/fork/createScope.ts
@@ -71,8 +71,15 @@ export function createScope(unit?: Domain): Scope {
             forkPage.sidValuesMap[sid] = value
 
             const serialize = getMeta(storeNode, 'serialize')
-            if (serialize && serialize !== 'ignore') {
-              forkPage.sidSerializeMap[sid] = serialize.write
+            if (serialize) {
+              if (serialize === 'ignore') {
+                forkPage.sidSerializeSettings.set(sid, {ignore: true})
+              } else {
+                forkPage.sidSerializeSettings.set(sid, {
+                  ignore: false,
+                  write: serialize.write,
+                })
+              }
             }
           }
         }
@@ -104,7 +111,7 @@ export function createScope(unit?: Domain): Scope {
     reg: page,
     sidValuesMap: {},
     sidIdMap: {},
-    sidSerializeMap: {},
+    sidSerializeSettings: new Map(),
     getState(store: StateRef | Store<any>) {
       if ('current' in store) {
         return getPageRef(currentPage, resultScope, null, store).current
@@ -117,7 +124,7 @@ export function createScope(unit?: Domain): Scope {
     graphite: createNode({
       family: {
         type: DOMAIN,
-        links: [forkInFlightCounter, storeChange, warnSerializeNode],
+        links: [storeChange, forkInFlightCounter, warnSerializeNode],
       },
       meta: {unit: 'fork'},
       scope: {forkInFlightCounter},

--- a/src/effector/fork/fork.ts
+++ b/src/effector/fork/fork.ts
@@ -13,13 +13,13 @@ type ForkConfig = {
 
 export function fork(
   domainOrConfig?: Domain | ForkConfig,
-  optiionalConfig?: ForkConfig,
+  optionalConfig?: ForkConfig,
 ) {
   let config: ForkConfig | void = domainOrConfig as any
   let domain: Domain
   if (is.domain(domainOrConfig)) {
     domain = domainOrConfig
-    config = optiionalConfig
+    config = optionalConfig
   }
 
   const scope = createScope(domain!)

--- a/src/effector/fork/serialize.ts
+++ b/src/effector/fork/serialize.ts
@@ -22,7 +22,12 @@ export function serialize(
   forIn(scope.sidValuesMap, (value, sid) => {
     if (includes(ignoredStores, sid)) return
     const id = scope.sidIdMap[sid]
-    const serializer = scope.sidSerializeMap[sid] || noopSerializer
+    const serializeSettings = scope.sidSerializeSettings.get(sid) ?? {
+      ignore: false,
+      write: noopSerializer,
+    }
+    if (serializeSettings.ignore) return
+    const serializer = serializeSettings.write
     // if (!scope.changedStores.has(id)) return
     if (id && id in scope.reg) {
       result[sid] = serializer(scope.reg[id].current)

--- a/src/effector/unit.h.ts
+++ b/src/effector/unit.h.ts
@@ -174,7 +174,10 @@ export interface Scope extends Unit {
   /** value could be set only for stores with sid (they can be created by createStore, restore and combine) */
   sidValuesMap: Record<string, any>
   sidIdMap: Record<string, string>
-  sidSerializeMap: Record<string, (p: any) => any>
+  sidSerializeSettings: Map<
+    string,
+    {ignore: true} | {ignore: false; write: (value: any) => any}
+  >
   additionalLinks: Record<string, Node[]>
   handlers: Record<string, (params: unknown) => any>
   fxCount: Node


### PR DESCRIPTION
Fixes #861