### PR TITLE
beta: Fully rewrite `Event` API page

### DIFF
--- a/beta/src/components/RightSidebar/TableOfContents.module.css
+++ b/beta/src/components/RightSidebar/TableOfContents.module.css
@@ -18,7 +18,7 @@
   @apply scroll-py-6 py-1;
 }
 
-ul.contents {
+:global(.content) ul.contents {
   list-style-type: none;
   @apply text-base;
 }

--- a/beta/src/consts.ts
+++ b/beta/src/consts.ts
@@ -65,7 +65,7 @@ export const COMMUNITY_INVITE_URL = LINKS.discord;
 export const ALGOLIA = {
   indexName: "effector-beta",
   appId: "ARB8LV9Z4L",
-  apiKey: process.env.ALGOLIA_API_KEY!,
+  apiKey: import.meta.env.ALGOLIA_API_KEY!,
 };
 
 export const ANNOUNCEMENT: Announcement | null = {

--- a/beta/src/content/docs/en/api/effector/Event.md
+++ b/beta/src/content/docs/en/api/effector/Event.md
@@ -11,7 +11,7 @@ redirectFrom:
 
 The **Event** in effector represents a user action, a step in the application process, a command to execute, or an intention to make modifications, among other things. This unit is designed to be a carrier of information/intention/state within the application, not the holder of a state.
 
-There are two type of events provided by effector: [`Event`](#event) and [`ListenEvent`](#listenEvent).
+There are two type of events provided by effector: [`Event`](#event) and [`ReadonlyEvent`](#readonlyEvent).
 
 # Event instance {#event}
 
@@ -29,15 +29,15 @@ There are many ways to create event:
 
 - the most common [`createEvent`](/en/api/effector/createEvent)
 - using [Domain createEvent](/en/api/effector/Domain#createeventname)
-- via [Event's methods](#event-methods) and it's supertype [ListenEvent's methods](#listenEvent-methods)
-- some [Effect's methods](/en/api/effector/Effect#methods) return new Events
+- via [Event's methods](#event-methods) and it's supertype [ReadonlyEvent's methods](#readonlyEvent-methods)
+- some [Effect's methods](/en/api/effector/Effect#methods) return new events and readonly events
 - operators such as: [`createApi`](/en/api/effector/createApi)
 
 ## Calling the event {#event-calling}
 
 There are two ways to trigger event: imperative and declarative.
 
-The imperative method involves invoking the event as if it were a function:
+The **imperative** method involves invoking the event as if it were a function:
 
 ```ts
 import { createEvent } from "effector";
@@ -47,7 +47,7 @@ const callHappened = createEvent<void>();
 callHappened(); // event triggered
 ```
 
-The declarative approach utilizes the event as a target for operators, such as sample, or as an argument when passed into factory functions:
+The **declarative** approach utilizes the event as a target for operators, such as sample, or as an argument when passed into factory functions:
 
 ```ts
 import { createEvent, sample } from "effector";
@@ -72,6 +72,7 @@ It is not possible to call an event with two or more arguments, as in `someEvent
 
 All arguments beyond the first will be disregarded.
 The core team has implemented this rule for specific reasons related to the design and functionality.
+Read more in the explanation section.
 :::
 
 If multiple arguments need to be passed, encapsulate them within an object:
@@ -122,7 +123,7 @@ sample({
 
 To specify the argument type for an event, it is essential to first determine the intended purpose, what do you want to do with this event:
 - If you intend to **invoke** an event or use it as a target, you should utilize the `Event<T>` type.
-- If your goal is to **subscribe** to updates, or use the event as a `clock` or `source`, you should employ the `ListenEvent<T>` type.
+- If your goal is to **subscribe** to updates, or use the event as a `clock` or `source`, you should employ the `ReadonlyEvent<T>` type.
 
 _Where `T` represents the type of the event's argument._
 
@@ -149,7 +150,7 @@ firstTriggered();
 // => [event] secondTriggered undefined
 ```
 
-However, if your environment does not permit the addition of further dependencies, you may use the [`.watch()`](#listenEvent-watch-watcher) method with caution.
+However, if your environment does not permit the addition of further dependencies, you may use the [`.watch()`](#readonlyEvent-watch-watcher) method with caution.
 
 ```ts
 import { createEvent, sample } from "effector";
@@ -170,6 +171,14 @@ firstTriggered();
 // => [event] secondTriggered
 ```
 
+:::tip{title="Keep in mind"}
+
+The `watch` method neither handles nor reports exceptions, manages the completion of asynchronous operations, nor addresses data race issues.
+
+Its primary intended use is for short-term debugging and logging purposes.
+
+:::
+
 ## Formulae {#event-formulae}
 
 ```ts
@@ -186,46 +195,46 @@ event(argument: T): T
 
 ### `prepend(fn)` {#event-prepend-fn}
 
-# ListenEvent instance {#listenEvent}
+# ReadonlyEvent instance {#readonlyEvent}
 
-A **ListenEvent** is a more common type of event with different approach Firstly, invoking a ListenEvent is not allowed, and it cannot be used as a `target` in the `sample` operator, and so on.
+A **ReadonlyEvent** is a more common type of event with different approach Firstly, invoking a ReadonlyEvent is not allowed, and it cannot be used as a `target` in the `sample` operator, and so on.
 
-The primary purpose of a ListenEvent is to be triggered by internal code withing the effector library or ecosystem. For instance, the `.map()` method returns a ListenEvent, which is subsequently called by the `.map()` method itself.
+The primary purpose of a ReadonlyEvent is to be triggered by internal code withing the effector library or ecosystem. For instance, the `.map()` method returns a ReadonlyEvent, which is subsequently called by the `.map()` method itself.
 
 :::info
-There is no need for user code to directly invoke such a ListenEvent.
+There is no need for user code to directly invoke such a ReadonlyEvent.
 :::
 
-All the functionalities provided by ListenEvent are also supported in a regular Event.
+All the functionalities provided by ReadonlyEvent are also supported in a regular Event.
 
-## Construction {#listenEvent-construction}
+## Construction {#readonlyEvent-construction}
 
-There is no way to manually create ListenEvent, but some methods and operators returns derived events:
+There is no way to manually create ReadonlyEvent, but some methods and operators returns derived events, they are have `ReadonlyEvent<T>` type:
 
 - Event's methods like: [`.map(fn)`](#event-map-fn), [`.filter({fn})`](#event-filterMap-fn), and so on
 - Store's property: ['.updates'](/en/api/effector/Store#updates)
 - Effect's [methods](/en/api/effector/Effect#effect) and [properties](/en/api/effector/Effect#properties)
 - operators like: [`sample`](/en/api/effector/sample), [`merge`](/en/api/effector/merge)
 
-## Methods {#listenEvent-methods}
+## Methods {#readonlyEvent-methods}
 
-### `map(fn)` {#listenEvent-map-fn}
+### `map(fn)` {#readonlyEvent-map-fn}
 
-### `filter({ fn })` {#listenEvent-filter-fn}
+### `filter({ fn })` {#readonlyEvent-filter-fn}
 
-### `filterMap(fn)` {#listenEvent-filterMap-fn}
+### `filterMap(fn)` {#readonlyEvent-filterMap-fn}
 
-### `watch(watcher)` {#listenEvent-watch-watcher}
+### `watch(watcher)` {#readonlyEvent-watch-watcher}
 
-### `subscribe(observer)` {#listenEvent-subscribe-observer}
+### `subscribe(observer)` {#readonlyEvent-subscribe-observer}
 
-## Properties {#listenEvent-properties}
+## Properties {#readonlyEvent-properties}
 
-### `sid` {#listenEvent-sid}
+### `sid` {#readonlyEvent-sid}
 
-### `compositeName` {#listenEvent-compositeName}
+### `compositeName` {#readonlyEvent-compositeName}
 
-### `shortName` {#listenEvent-shortName}
+### `shortName` {#readonlyEvent-shortName}
 
 ---
 

--- a/beta/src/content/docs/en/api/effector/Event.md
+++ b/beta/src/content/docs/en/api/effector/Event.md
@@ -538,6 +538,8 @@ And you repeat this until you complete the task. Now think about it in the effec
 
 ### `watch(watcher)` {#readonlyEvent-watch-watcher}
 
+This method enables you to call callback on each event trigger with the argument of the event.
+
 :::tip{title="Keep in mind"}
 The `watch` method neither handles nor reports exceptions, manages the completion of asynchronous operations, nor addresses data race issues.
 
@@ -545,6 +547,17 @@ Its primary intended use is for short-term debugging and logging purposes.
 :::
 
 ### `subscribe(observer)` {#readonlyEvent-subscribe-observer}
+
+This is the low-level method to integrate event with the standard `Observable` pattern.
+
+:::tip{title="Keep in mind"}
+You don't need to use this method on your own. It is used under the hood by rendering engines or so on.
+:::
+
+Read more:
+
+- https://rxjs.dev/guide/observable
+- https://github.com/tc39/proposal-observable
 
 ## Properties {#readonlyEvent-properties}
 

--- a/beta/src/content/docs/en/api/effector/Event.md
+++ b/beta/src/content/docs/en/api/effector/Event.md
@@ -594,8 +594,50 @@ Read more:
 
 ## Properties {#readonlyEvent-properties}
 
+These set of property is mostly set by [`effector/babel-plugin`](/en/api/effector/babel-plugin) or [`@effector/swc-plugin`](https://github.com/effector/swc-plugin). So they are exist only when babel or SWC is used.
+
 ### `sid` {#readonlyEvent-sid}
+
+It is an unique identifier for each event.
+
+It is important to note, SID is not changes on each app start, it is statically written inside your app bundle to absolutely identify units.
+
+It can be useful to send events between workers or server/browser: [examples/worker-rpc](https://github.com/effector/effector/tree/master/examples/worker-rpc).
+
+It has the `string | null` type.
+
+### `shortName` {#readonlyEvent-shortName}
+
+It is a `string` type property, contains the name of the variable event declared at.
+
+```ts
+import { createEvent } from "effector";
+
+const demo = createEvent();
+// demo.shortName === 'demo'
+```
+
+But reassign event to another variable changes nothing:
+
+```ts
+const another = demo;
+// another.shortName === 'demo'
+```
 
 ### `compositeName` {#readonlyEvent-compositeName}
 
-### `shortName` {#readonlyEvent-shortName}
+This property contains the full internal chain of units. For example, event can be created by the domain, so the composite name will contain a domain name inside it.
+
+```ts
+import { createEvent, createDomain } from "effector";
+
+const first = createEvent();
+const domain = createDomain();
+const second = domain.createEvent();
+
+console.log(first);
+// => { shortName: "first", fullName: "first", path: ["first"] }
+
+console.log(second);
+// => { shortName: "second", fullName: "domain/second", path: ["domain", "second"] }
+```

--- a/beta/src/content/docs/en/api/effector/Event.md
+++ b/beta/src/content/docs/en/api/effector/Event.md
@@ -85,7 +85,7 @@ requestReceived({ id: 1, title: "example" })
 
 This rule also contributes to the clarity of each argument's meaning, both at the call site and subscription site. It promotes clean and organized code, making it easier to understand and maintain
 
-## Typing the argument
+## Declaring types
 
 Event carriers some data, in TypeScript ecosystem each data should have defined type.
 When event is explicitly created by [`createEvent`](/en/api/effector/createEvent) type of the argument must be provided as a Generic type argument:
@@ -126,6 +126,21 @@ To specify the argument type for an event, it is essential to first determine th
 - If your goal is to **subscribe** to updates, or use the event as a `clock` or `source`, you should employ the `ReadonlyEvent<T>` type.
 
 _Where `T` represents the type of the event's argument._
+
+```ts
+import { type Event, createStore, createEvent } from 'effector'
+
+function createCounter(counterChanged: Event<number>) {
+  const $counter = createStore(0)
+  sample({
+    clock: $counter,
+    target: counterChanged,
+  })
+}
+
+const whenCounterChanged = createEvent<number>()
+createCounter(whenCounterChanged)
+```
 
 ## Watching the event {#event-watch}
 
@@ -172,11 +187,9 @@ firstTriggered();
 ```
 
 :::tip{title="Keep in mind"}
-
 The `watch` method neither handles nor reports exceptions, manages the completion of asynchronous operations, nor addresses data race issues.
 
 Its primary intended use is for short-term debugging and logging purposes.
-
 :::
 
 ## Formulae {#event-formulae}
@@ -195,14 +208,19 @@ event(argument: T): T
 
 ### `prepend(fn)` {#event-prepend-fn}
 
+<br/><br/>
+
 # ReadonlyEvent instance {#readonlyEvent}
 
-A **ReadonlyEvent** is a more common type of event with different approach Firstly, invoking a ReadonlyEvent is not allowed, and it cannot be used as a `target` in the `sample` operator, and so on.
+A **ReadonlyEvent** is a super type of `Event` with different approach. Firstly, invoking a ReadonlyEvent is not allowed, and it cannot be used as a `target` in the `sample` operator, and so on.
 
 The primary purpose of a ReadonlyEvent is to be triggered by internal code withing the effector library or ecosystem. For instance, the `.map()` method returns a ReadonlyEvent, which is subsequently called by the `.map()` method itself.
 
 :::info
 There is no need for user code to directly invoke such a ReadonlyEvent.
+
+
+If you find yourself needing to call a ReadonlyEvent, it may be necessary to reevaluate and restructure your application's logic.
 :::
 
 All the functionalities provided by ReadonlyEvent are also supported in a regular Event.
@@ -216,6 +234,32 @@ There is no way to manually create ReadonlyEvent, but some methods and operators
 - Effect's [methods](/en/api/effector/Effect#effect) and [properties](/en/api/effector/Effect#properties)
 - operators like: [`sample`](/en/api/effector/sample), [`merge`](/en/api/effector/merge)
 
+## Declaring types
+
+It becomes necessary in cases where a factory or library requires an event to subscribe to its updates, ensuring proper integration and interaction with the provided functionality:
+
+```ts
+ReadonlyEvent<T>;
+```
+
+_Where `T` represents the type of the event's argument._
+
+To utilize the `ReadonlyEvent` type, simply import it from the `"effector"` package and integrate it into your code as needed:
+
+```ts
+import { type ReadonlyEvent, createStore, createEvent } from 'effector'
+
+function createCounter(increment: ReadonlyEvent<void>) {
+  const $counter = createStore(0)
+
+  $counter.on(increment, (count) => count + 1)
+}
+
+const incrementCounter = createEvent<number>()
+createCounter(incrementCounter)
+incrementCounter()
+```
+
 ## Methods {#readonlyEvent-methods}
 
 ### `map(fn)` {#readonlyEvent-map-fn}
@@ -226,6 +270,12 @@ There is no way to manually create ReadonlyEvent, but some methods and operators
 
 ### `watch(watcher)` {#readonlyEvent-watch-watcher}
 
+:::tip{title="Keep in mind"}
+The `watch` method neither handles nor reports exceptions, manages the completion of asynchronous operations, nor addresses data race issues.
+
+Its primary intended use is for short-term debugging and logging purposes.
+:::
+
 ### `subscribe(observer)` {#readonlyEvent-subscribe-observer}
 
 ## Properties {#readonlyEvent-properties}
@@ -235,16 +285,3 @@ There is no way to manually create ReadonlyEvent, but some methods and operators
 ### `compositeName` {#readonlyEvent-compositeName}
 
 ### `shortName` {#readonlyEvent-shortName}
-
----
-
-- event methods
-  - map: DerivedEvent
-  - filter: DerivedEvent
-  - filterMap: DerivedEvent
-  - prepend: Event
-  - watch:
-- properties
-  - sid
-  - shortName
-  - compositeName

--- a/beta/src/content/docs/en/api/effector/Event.md
+++ b/beta/src/content/docs/en/api/effector/Event.md
@@ -546,6 +546,39 @@ The `watch` method neither handles nor reports exceptions, manages the completio
 Its primary intended use is for short-term debugging and logging purposes.
 :::
 
+#### Formulae {#readonlyEvent-watch-watcher-formulae}
+
+```ts
+const unwatch = event.watch(fn);
+```
+
+- The `fn` will be called on each `event` trigger, passed argument of the `event` to the `fn`.
+- When `unwatch` is called, stop calling `fn` on each `event` trigger.
+
+#### Arguments {#readonlyEvent-watch-watcher-arguments}
+
+1. `watcher` ([_Watcher_](/en/explanation/glossary#watcher)): A function that receives `argument` from the event.
+
+#### Returns {#readonlyEvent-watch-watcher-returns}
+
+[_Subscription_](/en/explanation/glossary#subscription): Unsubscribe function.
+
+#### Example {#readonlyEvent-watch-watcher-example}
+
+```js
+import { createEvent } from "effector";
+
+const sayHi = createEvent();
+const unwatch = sayHi.watch((name) => console.log(`${name}, hi there!`));
+
+sayHi("Peter"); // => Peter, hi there!
+unwatch();
+
+sayHi("Drew"); // => nothing happened
+```
+
+[Try it](https://share.effector.dev/9YVgCl4C)
+
 ### `subscribe(observer)` {#readonlyEvent-subscribe-observer}
 
 This is the low-level method to integrate event with the standard `Observable` pattern.

--- a/beta/src/content/docs/en/api/effector/Event.md
+++ b/beta/src/content/docs/en/api/effector/Event.md
@@ -58,6 +58,8 @@ const maybeDataReceived = createEvent<Data | null>();
 // maybeDataReceived: Event<Data | null>
 ```
 
+[Read more in the explanation section](/en/explanation/events#typescript).
+
 ## Methods {#event-methods}
 
 All the methods and properties from [ReadonlyEvent](#readonlyEvent-methods) is also available on `Event` instance.
@@ -72,6 +74,8 @@ You can think of the Event and ReadonlyEvent as type and its super type:
 
 Initiates an event with the provided argument, which in turn activates any registered subscribers.
 
+[Read more in the explanation section](/en/explanation/events#event-calling).
+
 #### Formulae {#event-argument-formulae}
 
 ```ts
@@ -83,6 +87,15 @@ event(argument: T): T
 - all subscribers of event receives the `argument` passed into
 - when `T` is `void`, `event` can be called without arguments
 - `T` by default is `void`, so generic type argument can be omitted
+
+:::warning{title="Important"}
+
+In Effector, any event supports only **a single argument**.
+It is not possible to call an event with two or more arguments, as in `someEvent(first, second)`.
+
+All arguments beyond the first will be ignored.
+The core team has implemented this rule for specific reasons related to the design and functionality.
+:::
 
 #### Arguments {#event-argument-arguments}
 
@@ -247,6 +260,8 @@ ReadonlyEvent<T>;
 ```
 
 _Where `T` represents the type of the event's argument._
+
+[Read more in the explanation section](/en/explanation/events#readonlyEvent-using).
 
 ## Methods {#readonlyEvent-methods}
 
@@ -503,6 +518,8 @@ The `watch` method neither handles nor reports exceptions, manages the completio
 
 Its primary intended use is for short-term debugging and logging purposes.
 :::
+
+[Read more in the explanation section](/en/explanation/events#event-watch).
 
 #### Formulae {#readonlyEvent-watch-watcher-formulae}
 

--- a/beta/src/content/docs/en/api/effector/Event.md
+++ b/beta/src/content/docs/en/api/effector/Event.md
@@ -13,16 +13,6 @@ The **Event** in effector represents a user action, a step in the application pr
 
 There are two type of events provided by effector: [`Event`](#event) and [`ReadonlyEvent`](#readonlyEvent).
 
-# Event instance {#event}
-
-In most situations, it is recommended to create events directly within the module, rather than placing them within conditional statements or classes, in order to maintain simplicity and readability. An exception to this recommendation is the use of factory functions; however, these should also be invoked at the root level of the module.
-
-:::info
-Event instances persist throughout the entire runtime of the application and inherently represent a portion of the business logic.
-
-Attempting to delete instances and clear memory for the purpose of saving resources is not advised, as it may adversely impact the functionality and performance of the application.
-:::
-
 ## Construction {#event-construction}
 
 There are many ways to create event:
@@ -32,58 +22,6 @@ There are many ways to create event:
 - via [Event's methods](#event-methods) and it's supertype [ReadonlyEvent's methods](#readonlyEvent-methods)
 - some [Effect's methods](/en/api/effector/Effect#methods) return new events and readonly events
 - operators such as: [`createApi`](/en/api/effector/createApi)
-
-## Calling the event {#event-calling}
-
-There are two ways to trigger event: imperative and declarative.
-
-The **imperative** method involves invoking the event as if it were a function:
-
-```ts
-import { createEvent } from "effector";
-
-const callHappened = createEvent<void>();
-
-callHappened(); // event triggered
-```
-
-The **declarative** approach utilizes the event as a target for operators, such as sample, or as an argument when passed into factory functions:
-
-```ts
-import { createEvent, sample } from "effector";
-
-const firstTriggered = createEvent<void>();
-const secondTriggered = createEvent<void>();
-
-sample({
-  clock: firstTriggered,
-  target: secondTriggered,
-});
-```
-
-> When the `firstTriggered` event is invoked, the `secondTriggered` event will be subsequently called, creating a sequence of events.
-
-This method is employed to link various units within a single event chain. In most cases, the chain will have multiple branches, allowing for diverse interactions and processes within the application logic.
-
-:::warning{title="Important"}
-
-In Effector, any event supports only **a single argument**.
-It is not possible to call an event with two or more arguments, as in `someEvent(first, second)`.
-
-All arguments beyond the first will be disregarded.
-The core team has implemented this rule for specific reasons related to the design and functionality.
-Read more in the explanation section.
-:::
-
-If multiple arguments need to be passed, encapsulate them within an object:
-
-```ts
-import { createEvent } from "effector";
-const requestReceived = createEvent<{ id: number; title: string }>();
-requestReceived({ id: 1, title: "example" });
-```
-
-This rule also contributes to the clarity of each argument's meaning, both at the call site and subscription site. It promotes clean and organized code, making it easier to understand and maintain
 
 ## Declaring types
 
@@ -99,47 +37,6 @@ interface ItemAdded {
 }
 
 const itemAdded = createEvent<ItemAdded>();
-```
-
-When an event is invoked, TypeScript will verify that the type of the argument passed matches the type defined in the event, ensuring consistency and type safety within the code.
-
-This is also works for operators like `sample` or `split`:
-
-```ts
-import { sample, createEvent } from "effector";
-
-const someHappened = createEvent<number>();
-const anotherHappened = createEvent<string>();
-
-sample({
-  // @ts-expect-error error: "clock should extend target type"; targets: { clockType: number; targetType: string; }
-  clock: someHappened,
-  target: anotherHappened,
-});
-```
-
-[Try it](https://tsplay.dev/WyoPKN)
-
-To specify the argument type for an event, it is essential to first determine the intended purpose, what do you want to do with this event:
-
-- If you intend to **invoke** an event or use it as a target, you should utilize the `Event<T>` type.
-- If your goal is to **subscribe** to updates, or use the event as a `clock` or `source`, you should employ the `ReadonlyEvent<T>` type.
-
-_Where `T` represents the type of the event's argument._
-
-```ts
-import { type Event, createStore, createEvent } from "effector";
-
-function createCounter(counterChanged: Event<number>) {
-  const $counter = createStore(0);
-  sample({
-    clock: $counter,
-    target: counterChanged,
-  });
-}
-
-const whenCounterChanged = createEvent<number>();
-createCounter(whenCounterChanged);
 ```
 
 In the most cases there is no reason to use `void` with the another type (~~`Event<void | number>`~~). Use `void` only to declare the Event or ReadonlyEvent without the argument at all.
@@ -161,68 +58,6 @@ const maybeDataReceived = createEvent<Data | null>();
 // maybeDataReceived: Event<Data | null>
 ```
 
-## Watching the event {#event-watch}
-
-To ascertain when an event is called, effector and its ecosystem offer various methods with distinct capabilities. Debugging is the primary use case for this purpose, and we highly recommend using [`patronum/debug`](https://patronum.effector.dev/methods/debug/) to display when an event is triggered and the argument it carries.
-
-```ts
-import { createEvent, sample } from "effector";
-import { debug } from "patronum";
-
-const firstTriggered = createEvent<void>();
-const secondTriggered = createEvent<void>();
-
-sample({
-  clock: firstTriggered,
-  target: secondTriggered,
-});
-
-debug(firstTriggered, secondTriggered);
-
-firstTriggered();
-// => [event] firstTriggered undefined
-// => [event] secondTriggered undefined
-```
-
-However, if your environment does not permit the addition of further dependencies, you may use the [`.watch()`](#readonlyEvent-watch-watcher) method with caution.
-
-```ts
-import { createEvent, sample } from "effector";
-
-const firstTriggered = createEvent<void>();
-const secondTriggered = createEvent<void>();
-
-sample({
-  clock: firstTriggered,
-  target: secondTriggered,
-});
-
-firstTriggered.watch(() => console.info("[event] firstTriggered"));
-secondTriggered.watch(() => console.info("[event] secondTriggered"));
-
-firstTriggered();
-// => [event] firstTriggered
-// => [event] secondTriggered
-```
-
-:::tip{title="Keep in mind"}
-The `watch` method neither handles nor reports exceptions, manages the completion of asynchronous operations, nor addresses data race issues.
-
-Its primary intended use is for short-term debugging and logging purposes.
-:::
-
-## Formulae {#event-formulae}
-
-```ts
-const event = createEvent<T>()
-event(argument: T): T
-```
-
-- `event` called as a function always returns its argument as is
-- all subscribers of event receives the `argument` passed into
-- when `T` is `void`, `event` can be called without arguments
-- `T` by default is `void`, so generic type argument can be omitted
-
 ## Methods {#event-methods}
 
 All the methods and properties from [ReadonlyEvent](#readonlyEvent-methods) is also available on `Event` instance.
@@ -232,6 +67,47 @@ You can think of the Event and ReadonlyEvent as type and its super type:
 
 `Event<T> extends ReadonlyEvent<T>`
 :::
+
+### `event(argument)` {#event-argument}
+
+Initiates an event with the provided argument, which in turn activates any registered subscribers.
+
+#### Formulae {#event-argument-formulae}
+
+```ts
+const event: Event<T>
+event(argument: T): T
+```
+
+- `event` called as a function always returns its argument as is
+- all subscribers of event receives the `argument` passed into
+- when `T` is `void`, `event` can be called without arguments
+- `T` by default is `void`, so generic type argument can be omitted
+
+#### Arguments {#event-argument-arguments}
+
+1. `event` is an instance of `Event<T>`
+2. `argument` is a value of `T`. It is optional, if event is defined as `Event<void>`.
+
+#### Returns {#event-argument-returns}
+
+_`T`_: Represents the same value that is passed into the `event`.
+
+#### Types {#event-argument-types}
+
+```ts
+import { createEvent, Event } from "effector";
+
+const someHappened = createEvent<number>();
+// someHappened: Event<number>
+someHappened(1);
+
+const anotherHappened = createEvent();
+// anotherHappened: Event<void>
+anotherHappened();
+```
+
+An event can be specified with a single generic type argument. By default, this argument is set to void, indicating that the event does not accept any parameters.
 
 ### `prepend(fn)` {#event-prepend-fn}
 
@@ -371,22 +247,6 @@ ReadonlyEvent<T>;
 ```
 
 _Where `T` represents the type of the event's argument._
-
-To utilize the `ReadonlyEvent` type, simply import it from the `"effector"` package and integrate it into your code as needed:
-
-```ts
-import { type ReadonlyEvent, createStore, createEvent } from "effector";
-
-function createCounter(increment: ReadonlyEvent<void>) {
-  const $counter = createStore(0);
-
-  $counter.on(increment, (count) => count + 1);
-}
-
-const incrementCounter = createEvent<number>();
-createCounter(incrementCounter);
-incrementCounter();
-```
 
 ## Methods {#readonlyEvent-methods}
 

--- a/beta/src/content/docs/en/api/effector/Event.md
+++ b/beta/src/content/docs/en/api/effector/Event.md
@@ -25,7 +25,7 @@ There are many ways to create event:
 
 ## Declaring types
 
-Event carriers some data, in TypeScript ecosystem each data should have defined type.
+Event carries some data and in TypeScript ecosystem each data should have defined type.
 When event is explicitly created by [`createEvent`](/en/api/effector/createEvent) type of the argument must be provided as a Generic type argument:
 
 ```ts

--- a/beta/src/content/docs/en/explanation/events.md
+++ b/beta/src/content/docs/en/explanation/events.md
@@ -1,0 +1,183 @@
+---
+title: Events
+keywords:
+  - event
+  - unit
+description: How events works, where to use
+---
+
+The **Event** in effector represents a user action, a step in the application process, a command to execute, or an intention to make modifications, among other things. This unit is designed to be a carrier of information/intention/state within the application, not the holder of a state.
+
+In most situations, it is recommended to create events directly within the module, rather than placing them within conditional statements or classes, in order to maintain simplicity and readability. An exception to this recommendation is the use of factory functions; however, these should also be invoked at the root level of the module.
+
+:::info
+Event instances persist throughout the entire runtime of the application and inherently represent a portion of the business logic.
+
+Attempting to delete instances and clear memory for the purpose of saving resources is not advised, as it may adversely impact the functionality and performance of the application.
+:::
+
+## Calling the event {#event-calling}
+
+There are two ways to trigger event: imperative and declarative.
+
+The **imperative** method involves invoking the event as if it were a function:
+
+```ts
+import { createEvent } from "effector";
+
+const callHappened = createEvent<void>();
+
+callHappened(); // event triggered
+```
+
+The **declarative** approach utilizes the event as a target for operators, such as sample, or as an argument when passed into factory functions:
+
+```ts
+import { createEvent, sample } from "effector";
+
+const firstTriggered = createEvent<void>();
+const secondTriggered = createEvent<void>();
+
+sample({
+  clock: firstTriggered,
+  target: secondTriggered,
+});
+```
+
+> When the `firstTriggered` event is invoked, the `secondTriggered` event will be subsequently called, creating a sequence of events.
+
+This method is employed to link various units within a single event chain. In most cases, the chain will have multiple branches, allowing for diverse interactions and processes within the application logic.
+
+**You need to know:** In Effector, any event supports only **a single argument**.
+It is not possible to call an event with two or more arguments, as in `someEvent(first, second)`.
+
+All arguments beyond the first will be ignored.
+The core team has implemented this rule for specific reasons related to the design and functionality.
+This approach enables the argument to be accessed in any situation without adding types complexity.
+
+If multiple arguments need to be passed, encapsulate them within an object:
+
+```ts
+import { createEvent } from "effector";
+const requestReceived = createEvent<{ id: number; title: string }>();
+requestReceived({ id: 1, title: "example" });
+```
+
+This rule also contributes to the clarity of each argument's meaning, both at the call site and subscription site. It promotes clean and organized code, making it easier to understand and maintain
+
+## Watching the event {#event-watch}
+
+To ascertain when an event is called, effector and its ecosystem offer various methods with distinct capabilities. Debugging is the primary use case for this purpose, and we highly recommend using [`patronum/debug`](https://patronum.effector.dev/methods/debug/) to display when an event is triggered and the argument it carries.
+
+```ts
+import { createEvent, sample } from "effector";
+import { debug } from "patronum";
+
+const firstTriggered = createEvent<void>();
+const secondTriggered = createEvent<void>();
+
+sample({
+  clock: firstTriggered,
+  target: secondTriggered,
+});
+
+debug(firstTriggered, secondTriggered);
+
+firstTriggered();
+// => [event] firstTriggered undefined
+// => [event] secondTriggered undefined
+```
+
+However, if your environment does not permit the addition of further dependencies, you may use the [`.watch()`](#readonlyEvent-watch-watcher) method with caution.
+
+```ts
+import { createEvent, sample } from "effector";
+
+const firstTriggered = createEvent<void>();
+const secondTriggered = createEvent<void>();
+
+sample({
+  clock: firstTriggered,
+  target: secondTriggered,
+});
+
+firstTriggered.watch(() => console.info("[event] firstTriggered"));
+secondTriggered.watch(() => console.info("[event] secondTriggered"));
+
+firstTriggered();
+// => [event] firstTriggered
+// => [event] secondTriggered
+```
+
+:::tip{title="Keep in mind"}
+The `watch` method neither handles nor reports exceptions, manages the completion of asynchronous operations, nor addresses data race issues.
+
+Its primary intended use is for short-term debugging and logging purposes.
+:::
+
+## Working with TypeScript {#typescript}
+
+When an event is invoked, TypeScript will verify that the type of the argument passed matches the type defined in the event, ensuring consistency and type safety within the code.
+
+This is also works for operators like `sample` or `split`:
+
+```ts
+import { sample, createEvent } from "effector";
+
+const someHappened = createEvent<number>();
+const anotherHappened = createEvent<string>();
+
+sample({
+  // @ts-expect-error error: "clock should extend target type"; targets: { clockType: number; targetType: string; }
+  clock: someHappened,
+  target: anotherHappened,
+});
+```
+
+[Try it](https://tsplay.dev/WyoPKN)
+
+To specify the argument type for an event, it is essential to first determine the intended purpose, what do you want to do with this event:
+
+- If you intend to **invoke** an event or use it as a target, you should utilize the `Event<T>` type.
+- If your goal is to **subscribe** to updates, or use the event as a `clock` or `source`, you should employ the `ReadonlyEvent<T>` type.
+
+_Where `T` represents the type of the event's argument._
+
+```ts
+import { type Event, createStore, createEvent } from "effector";
+
+function createCounter(counterChanged: Event<number>) {
+  const $counter = createStore(0);
+  sample({
+    clock: $counter,
+    target: counterChanged,
+  });
+}
+
+const whenCounterChanged = createEvent<number>();
+createCounter(whenCounterChanged);
+```
+
+## Using `ReadonlyEvent` {#readonlyEvent-using}
+
+A ReadonlyEvent is a super type of `Event` with different approach. Firstly, invoking a ReadonlyEvent is not allowed, and it cannot be used as a target in the sample operator, and so on.
+
+The primary purpose of a ReadonlyEvent is to be triggered by internal code withing the effector library or ecosystem. For instance, the `.map()` method returns a ReadonlyEvent, which is subsequently called by the `.map()` method itself.
+
+To utilize the `ReadonlyEvent` type, simply import it from the `"effector"` package and integrate it into your code as needed:
+
+```ts
+import { type ReadonlyEvent, createStore, createEvent } from "effector";
+
+function createCounter(increment: ReadonlyEvent<void>) {
+  const $counter = createStore(0);
+
+  $counter.on(increment, (count) => count + 1);
+}
+
+const incrementCounter = createEvent<number>();
+createCounter(incrementCounter);
+incrementCounter();
+```
+
+There allowed to pass `Event<T>` into argument with type `ReadonlyEvent<T>`. The primary purpose of ReadonlyEvent is to accept any event type while explicitly signaling the code's intention to listen to the event, rather than invoking it.

--- a/beta/src/content/docs/en/explanation/glossary.md
+++ b/beta/src/content/docs/en/explanation/glossary.md
@@ -48,7 +48,7 @@ It is useful for logging or other side effects.
 
 [Domain](/en/api/effector/Domain) in api documentation
 
-## Unit
+## Unit {#unit}
 
 Data type used to describe business logic of applications. Most of the effector methods deal with unit processing.
 There are five unit types: [Store](/en/api/effector/Store), [Event](/en/api/effector/Event), [Effect](/en/api/effector/Effect), [Domain](/en/api/effector/Domain) and [Scope](/en/api/effector/Scope)

--- a/beta/src/navigation.ts
+++ b/beta/src/navigation.ts
@@ -108,6 +108,10 @@ const defaultSidebar: LSidebarGroup[] = [
         link: "/explanation/glossary",
       },
       {
+        text: { en: "Events", ru: "События" },
+        link: "/explanation/events",
+      },
+      {
         text: { en: "Computation Priority" },
         link: "/explanation/computation-priority",
       },

--- a/beta/src/styles/index.css
+++ b/beta/src/styles/index.css
@@ -221,24 +221,10 @@ article > section ol li {
   line-height: 2;
 }
 
-a > code {
-  position: relative;
-  background: transparent;
+body a > code {
   color: var(--theme-text-accent);
   text-underline-offset: var(--padding-block);
-}
-
-a > code::before {
-  display: block;
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  opacity: var(--theme-accent-opacity);
-  border-radius: var(--border-radius);
-  background: var(--theme-accent);
-  content: "";
+  background-color: hsla(var(--theme-accent-color), 0.1);
 }
 
 a:focus {

--- a/beta/src/styles/theme.css
+++ b/beta/src/styles/theme.css
@@ -84,7 +84,8 @@
 
 :root {
   --theme-accent-opacity: 0.15;
-  --theme-accent: hsl(var(--color-primary-50));
+  --theme-accent-color: var(--color-primary-50);
+  --theme-accent: hsl(var(--theme-accent-color));
   --theme-text-accent: hsl(var(--color-primary-50));
   --theme-divider: hsla(var(--color-gray-90), 1);
   --theme-divider-light: hsla(var(--color-gray-95), 0.6);
@@ -147,7 +148,8 @@ body {
 
 :root.theme-dark {
   --theme-accent-opacity: 0.15;
-  --theme-accent: hsla(var(--color-primary-50), 1);
+  --theme-accent-color: var(--color-primary-50);
+  --theme-accent: hsla(var(--theme-accent-color), 1);
   --theme-text-accent: hsla(var(--color-primary-40), 1);
   --theme-divider: hsla(var(--color-zinc-70), 1);
   --theme-divider-light: hsla(var(--color-gray-30), 0.6);


### PR DESCRIPTION
[Rendered API/Event](https://github.com/effector/effector/blob/docs/event-rewrite/beta/src/content/docs/en/api/effector/Event.md)

[Rendered Explanation/Events](https://github.com/effector/effector/blob/docs/event-rewrite/beta/src/content/docs/en/explanation/events.md)