### PR TITLE
Allow `domain` to be used in `attach` without parent effect

### DIFF
--- a/docs/api/effector/attach.md
+++ b/docs/api/effector/attach.md
@@ -161,6 +161,7 @@ Create effect which will call async function with values from `source` stores
 let resultFx: Effect<Params, Result>
 resultFx = attach({
   source: Store<Source>,
+  domain?: Domain,
   async effect(source: Source, params: Params): Result
 })
 ```
@@ -168,6 +169,7 @@ resultFx = attach({
 **Arguments**
 
 - `effect` (_Function_): `(source: Source, params: Params) => Promise<Result> | Result`
+- `domain` ([_Domain_](Domain.md)): An optional Domain that the effect will be a part of
 - `source` ([_Store_](Store.md) | `{[key: string]: Store}`): Store or object with stores, values of which will be passed to the first argument of `effect`
 
 **Returns**

--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -2730,6 +2730,7 @@ export function attach<
 >(config: {
   source: States
   effect: FX
+  domain?: Domain
   name?: string
 }): FX extends (source: any, ...args: infer Args) => infer Done
   ? Effect<OptionalParams<Args>, AsyncResult<Done>>

--- a/src/effector/__tests__/attach.test.ts
+++ b/src/effector/__tests__/attach.test.ts
@@ -381,3 +381,33 @@ test('attached effect should got its name from parent domain', () => {
   const attached = attach({effect: fx})
   expect(attached.compositeName.fullName).toBe('app/attached')
 })
+
+it('uses passed domain for function', () => {
+  const domain = createDomain()
+  const source = createStore(null)
+
+  const attached = attach({
+    source,
+    domain,
+    effect() {},
+  })
+
+  expect(attached.compositeName.fullName).toBe('domain/attached')
+})
+
+it('should not allow domain for effects', () => {
+  const domain = createDomain()
+  const source = createStore(null)
+  const fx = createEffect(() => {})
+
+  expect(() => {
+    attach({
+      source,
+      // @ts-expect-error
+      domain,
+      effect: fx,
+    })
+  }).toThrowErrorMatchingInlineSnapshot(
+    `"\`domain\` can only be used with a plain function"`,
+  )
+})

--- a/src/effector/__tests__/domain.test.ts
+++ b/src/effector/__tests__/domain.test.ts
@@ -252,6 +252,18 @@ describe('indirect child support', () => {
       })
       expect(argumentHistory(fn)).toEqual([fx, attached])
     })
+    test('with fn and explicit domain', () => {
+      const fn = jest.fn()
+      const domain = createDomain()
+      domain.onCreateEffect(e => fn(e))
+      const source = createStore(null)
+      const attached = attach({
+        source,
+        domain,
+        effect() {},
+      })
+      expect(argumentHistory(fn)).toEqual([attached])
+    })
   })
 })
 

--- a/src/effector/attach.ts
+++ b/src/effector/attach.ts
@@ -11,16 +11,23 @@ import {
   getCompositeName,
 } from './getter'
 import {own} from './own'
-import {is} from './is'
+import {is, isVoid} from './is'
 import {read, calc} from './step'
 import {launch} from './kernel'
 import {EFFECT} from './tag'
 import {createName} from './naming'
+import {assert} from './throw'
 
 export function attach(config: any) {
   let injected
   ;[config, injected] = processArgsToConfig(config, true)
-  let {source, effect, mapParams} = config
+  let {source, effect, mapParams, domain} = config
+  if (is.effect(effect)) {
+    assert(
+      isVoid(domain),
+      '`domain` can only be used with a plain function',
+    )
+  }
   const attached = createEffect(config, injected)
   setMeta(attached, 'attached', true)
   const {runner} = getGraph(attached).scope


### PR DESCRIPTION
Closes #829
Related #763