### PR TITLE
EFX-140 align header width in different parts of the website

### DIFF
--- a/documentation/src/layouts/Landing.astro
+++ b/documentation/src/layouts/Landing.astro
@@ -18,8 +18,8 @@ const { title, lang, description, dir = "ltr" } = Astro.props;
 </CommonLayout>
 
 <style>
-  <style > body {
-    --header-max-width: 100rem;
+  :root {
+    --header-max-width: 98rem;
   }
 
   .landing {

--- a/documentation/src/layouts/MainLayout.astro
+++ b/documentation/src/layouts/MainLayout.astro
@@ -39,7 +39,6 @@ const currentPage = Astro.url.pathname;
     :root {
       --gutter: 0.5rem;
       --content-max-width: 56rem;
-      --header-max-width: calc(100% - 1rem);
     }
 
     main {
@@ -85,7 +84,6 @@ const currentPage = Astro.url.pathname;
     @media (min-width: 768px) {
       :root {
         --sidebar-left-width: 20rem;
-        --header-max-width: calc(var(--sidebar-left-width) + var(--content-max-width));
       }
 
       .layout {


### PR DESCRIPTION
The inconsistency in the width of the header element was causing a layout shift issue, which happens when the user transitions from the landing page to the docs pages, and vice versa.

This merge request ensures that the widths across various sections of the website are consistent and aligned.

**Docs** 

![Xnip2023-11-03_23-31-47](https://github.com/effector/effector/assets/33234903/7e98bf20-ac01-4ba6-b986-a1b35b7f185e)

**Landing page (before)**
![Xnip2023-11-03_23-31-11](https://github.com/effector/effector/assets/33234903/656d26f4-c10f-411e-b134-dcc086923615)


**Landing page (after)**

![Xnip2023-11-03_23-32-11](https://github.com/effector/effector/assets/33234903/1b408dc0-ac75-47c0-9689-99b650a2802d)
