### PR TITLE
Add deprecation to useEvent overload

### DIFF
--- a/packages/effector-react/index.d.ts
+++ b/packages/effector-react/index.d.ts
@@ -159,6 +159,9 @@ export function useEvent<T, R>(
   fx: Effect<T, R, any>,
   opts?: {forceScope?: boolean},
 ): (payload: T) => Promise<R>
+/**
+ * @deprecated use useUnit hook instead
+ */
 export function useEvent<List extends (EventCallable<any> | Effect<any, any>)[]>(
   list: [...List],
   opts?: {forceScope?: boolean},


### PR DESCRIPTION
One of useEvent overloads was not marked as deprecated, therefore ide may not mark this method as deprecated
