### PR TITLE
Allow `name` in `attach` when only passing `effect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 See also [separate changelogs for each library](https://changelog.effector.dev/)
 
+## effector 23.2.3
+
+- Fix types for `attach({ effect })`, allowing to pass explicit `name` in this overload
+
 ## effector 23.2.2
 
 - Fix types for createEffect and attach in factories with generics ([issue #1069](https://github.com/effector/effector/issues/1069)). Cases like this now works correctly:

--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -2835,6 +2835,7 @@ export function attach<
   FX extends Effect<any, any, any>,
 >(config: {
   effect: FX
+  name?: string
 }): Effect<EffectParams<FX>, EffectResult<FX>, EffectError<FX>>
 /**
  * Method for creating state-dependent effect and transforming effect payload

--- a/src/types/__tests__/effector/attach.test.ts
+++ b/src/types/__tests__/effector/attach.test.ts
@@ -180,6 +180,16 @@ test('without source and mapParams (should pass)', () => {
   `)
 })
 
+test('effect with explicit name (should pass)', () => {
+  const effect: Effect<void, void, Error> = createEffect()
+  const fx: Effect<void, void, Error> = attach({effect, name: 'fx'})
+  expect(typecheck).toMatchInlineSnapshot(`
+    "
+    no errors
+    "
+  `)
+})
+
 describe('unknown params type', () => {
   test('unknown params type [with source] (?)', () => {
     const source = createStore(0)


### PR DESCRIPTION
Closes #1000