### PR TITLE
Delete `fork(domain)` overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ See also [separate changelogs for each library](https://changelog.effector.dev/)
 - Delete deprecated `effector/babel-plugin-react` ([PR #1088](https://github.com/effector/effector/pull/1088))
 - Improve SIDs generation mechanic: if unit is created by a registered factory, its SID will be derived from the SID of the factory ([PR #1063](https://github.com/effector/effector/pull/1063))
 - Delete deprecated `hydrate` function ([PR #1091](https://github.com/effector/effector/pull/1091))
+- Delete deprecated `fork(domain)` overload ([PR #1092](https://github.com/effector/effector/pull/1092))
+- Delete deprecated option `onlyChanges` in `fork` function ([PR #1092](https://github.com/effector/effector/pull/1092))
 
 ## effector-react 24.0.0
 

--- a/documentation/src/content/docs/en/api/effector/createStore.md
+++ b/documentation/src/content/docs/en/api/effector/createStore.md
@@ -202,7 +202,6 @@ $version.watch((version) => console.log("version %s", version));
 const scope = fork();
 
 // By default serialize saves value only for the changed stores
-// Review `onlyChanges` option https://effector.dev/api/effector/serialize
 const values = serialize(scope);
 console.log(values);
 // => {}

--- a/documentation/src/content/docs/en/api/effector/serialize.md
+++ b/documentation/src/content/docs/en/api/effector/serialize.md
@@ -40,19 +40,3 @@ An object with store values using sids as a keys
 :::warning{title="Reminder"}
 If a store [does not have a sid](/en/api/effector/babel-plugin#sid), its value will be omitted during serialization.
 :::
-
-### Examples (#methods-serialize-examples)
-
-#### Serialize forked instance state (#methods-serialize-examples-serializeForkedInstanceState)
-
-```js
-import { createDomain, fork, serialize } from "effector";
-
-const domain = createDomain();
-const $store = domain.createStore(42);
-const scope = fork(domain);
-
-console.log(serialize(scope)); // => {[sid]: 42}
-```
-
-[Try it](https://share.effector.dev/zlRJbjei)

--- a/documentation/src/content/docs/en/api/effector/serialize.md
+++ b/documentation/src/content/docs/en/api/effector/serialize.md
@@ -25,18 +25,13 @@ You can find deep-dive [explanation here](/en/explanation/sids)
 ### Formulae (#methods-serialize-formulae)
 
 ```ts
-serialize(scope: Scope, { ignore?: Array<Store<any>>; onlyChanges?: boolean }): {[sid: string]: any}
+serialize(scope: Scope, { ignore?: Array<Store<any>> }): {[sid: string]: any}
 ```
 
 ### Arguments (#methods-serialize-arguments)
 
 1. `scope` [_Scope_](/en/api/effector/Scope): a scope object (forked instance)
 2. `ignore` Optional array of [_Store_](/en/api/effector/Store) to be omitted during serialization (added 20.14.0)
-3. `onlyChanges` Optional boolean flag to ignore stores which didn't change in fork (prevent default values from being carried over network)
-
-:::warning{title="Deprecated"}
-Since [effector 23.0.0](https://changelog.effector.dev/#effector-23-0-0) property `onlyChanges` is deprecated.
-:::
 
 ### Returns (#methods-serialize-returns)
 
@@ -61,29 +56,3 @@ console.log(serialize(scope)); // => {[sid]: 42}
 ```
 
 [Try it](https://share.effector.dev/zlRJbjei)
-
-#### Using with `onlyChanges` (#methods-serialize-examples-usingWithOnlyChanges)
-
-With `onlyChanges`, this method will serialize only stores which were changed by some trigger during work or defined in `values` field by [fork](/en/api/effector/fork). Once being changed, a store will stay marked as changed in given scope even if it was turned back to the default state during work, otherwise client will not update that store on its side, which is unexpected and inconsistent.
-
-```js
-import { fork, serialize, createStore } from "effector";
-
-/** store which we want to fill by server */
-const $title = createStore("dashboard");
-
-/** store which is not used by server */
-const $clientTheme = createStore("light");
-
-const scope = fork({
-  values: [[$title, "chats"]],
-});
-
-/** this object will contain only $title data
- * as $clientTheme never changed in server scope */
-const chatsPageData = serialize(chatsPageScope, { onlyChanges: true });
-console.log(chatsPageData);
-// => {'-l644hw': 'chats'}
-```
-
-[Try it](https://share.effector.dev/BQhzISFV)

--- a/documentation/src/content/docs/ru/api/effector/Scope.md
+++ b/documentation/src/content/docs/ru/api/effector/Scope.md
@@ -33,18 +33,16 @@ scope.getState<T>(store: Store<T>): T
 Создание двух инстансов приложения, вызов событий в них и проверка сохранения значения стора `$counter` в каждом из них
 
 ```js
-import { createStore, createEvent, createDomain, fork, allSettled } from "effector";
+import { createStore, createEvent, fork, allSettled } from "effector";
 
-const domain = createDomain();
-const inc = domain.createEvent();
-const dec = domain.createEvent();
-const $counter = domain
-  .createStore(0)
+const inc = createEvent();
+const dec = createEvent();
+const $counter = createStore(0)
   .on(inc, (value) => value + 1)
   .on(dec, (value) => value - 1);
 
-const scopeA = fork(domain);
-const scopeB = fork(domain);
+const scopeA = fork();
+const scopeB = fork();
 
 await allSettled(inc, { scope: scopeA });
 await allSettled(dec, { scope: scopeB });

--- a/examples/react-ssr/src/server.tsx
+++ b/examples/react-ssr/src/server.tsx
@@ -4,7 +4,7 @@ import express from 'express'
 import {resolve} from 'path'
 import {promises as fs} from 'fs'
 import {fork, serialize, allSettled} from 'effector/fork'
-import {app, startServer, App} from './app'
+import {startServer, App} from './app'
 import users from './users.json'
 
 const port = process.env.PORT || 8080
@@ -16,7 +16,7 @@ const server = express()
 for (const key in users) {
   server.get(`/${key}`, async(req, res) => {
     try {
-      const scope = fork(app)
+      const scope = fork()
       await allSettled(startServer, {
         scope,
         params: users[key],

--- a/examples/serverless-ssr/src/server/ssr.ts
+++ b/examples/serverless-ssr/src/server/ssr.ts
@@ -5,7 +5,6 @@ import React from 'react'
 import {renderToString} from 'react-dom/server'
 import {fork, serialize, allSettled} from 'effector/fork'
 import {startServer, App} from '../app'
-import {app} from '../domain'
 import {APIGatewayProxyEvent} from 'aws-sdk'
 import domainConfig from '../../domain.json'
 
@@ -28,7 +27,7 @@ export default async (event: APIGatewayProxyEvent) => {
 
 async function dynamicContent(user) {
   try {
-    const scope = fork(app)
+    const scope = fork()
     await allSettled(startServer, {
       scope,
       params: user,

--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -2522,7 +2522,7 @@ export type ValueMap = Map<StoreWritable<any>, any> | Array<[StoreWritable<any>,
  */
 export function serialize(
   scope: Scope,
-  options?: {ignore?: Array<Store<any>>; onlyChanges?: boolean},
+  options?: {ignore?: Array<Store<any>> },
 ): {[sid: string]: any}
 
 /**

--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -2569,25 +2569,6 @@ export function fork(
   },
 ): Scope
 
-
-// legacy overloads
-/**
- * Creates isolated instance of application. Primary purposes of this method are SSR and testing.
- * 
- * @deprecated use `fork({values, handlers})` instead
- * 
- * @param domain optional root domain
- * @param config optional configuration object with initial store values and effect handlers
- * @returns new scope
- */
-export function fork(
-  domain: Domain,
-  config?: {
-    values?: SerializedState | LegacyMap | Array<[StoreWritable<any>, any]>,
-    handlers?: Handlers;
-  },
-): Scope
-
 /**
  * Run effect in scope and wait for all triggered effects to settle. This method never throw an error
  * @param unit effect to run

--- a/src/babel/__tests__/__snapshots__/babel-plugin.test.js.snap
+++ b/src/babel/__tests__/__snapshots__/babel-plugin.test.js.snap
@@ -2465,7 +2465,7 @@ function nameClashCheck() {
     name: 'domainEvent',
     sid: '-ai280s',
   })
-  const scope = fork(domain)
+  const scope = fork()
   const node = createNode()
   const a = attach({
     effect,
@@ -2563,7 +2563,7 @@ const domainEvent = domain.createEvent({
   name: 'domainEvent',
   sid: 't0scbd',
 })
-const scope = fork(domain)
+const scope = fork()
 const node = createNode()
 const a = attach({
   and: {
@@ -2794,7 +2794,7 @@ function outerScope() {
       name: 'domainEvent',
       sid: 'o78kmz',
     })
-    const scope = fork(domain)
+    const scope = fork()
     const node = createNode()
     const a = attach({
       effect,

--- a/src/babel/__tests__/fixtures/imports-globals.js
+++ b/src/babel/__tests__/fixtures/imports-globals.js
@@ -3,7 +3,7 @@ const event = createEvent()
 const store = createStore(0)
 const effect = createEffect()
 const domainEvent = domain.createEvent()
-const scope = fork(domain)
+const scope = fork()
 const node = createNode()
 
 const a = attach({effect})

--- a/src/babel/__tests__/fixtures/imports.js
+++ b/src/babel/__tests__/fixtures/imports.js
@@ -52,7 +52,7 @@ function nameClashCheck() {
   const store = createStore(0)
   const effect = createEffect()
   const domainEvent = domain.createEvent()
-  const scope = fork(domain)
+  const scope = fork()
   const node = createNode()
 
   const a = attach({effect})

--- a/src/babel/__tests__/fixtures/references.js
+++ b/src/babel/__tests__/fixtures/references.js
@@ -24,7 +24,7 @@ function outerScope() {
     const store = createStore(0)
     const effect = createEffect()
     const domainEvent = domain.createEvent()
-    const scope = fork(domain)
+    const scope = fork()
     const node = createNode()
 
     const a = attach({effect})

--- a/src/effector/__tests__/fork/fork.test.ts
+++ b/src/effector/__tests__/fork/fork.test.ts
@@ -13,25 +13,7 @@ import {
   Scope,
   StoreWritable,
 } from 'effector'
-import {argumentHistory, muteErrors} from 'effector/fixtures'
-
-muteErrors(['fork(domain)'])
-
-test('usage with domain', async () => {
-  const app = createDomain()
-  const add = app.createEvent<number>()
-  const $count = app.createStore(0).on(add, (n, x) => n + x)
-  const addFx = app.createEffect(() => 0)
-  sample({clock: addFx.doneData, target: add})
-
-  const scope = fork(app, {
-    values: [[$count, 10]],
-    handlers: [[addFx, () => 5]],
-  })
-  await allSettled(addFx, {scope})
-  expect(scope.getState($count)).toBe(15)
-  expect($count.getState()).toBe(0)
-})
+import {argumentHistory} from 'effector/fixtures'
 
 test('usage without domain', async () => {
   const add = createEvent<number>()
@@ -184,14 +166,12 @@ describe('units without sids support', () => {
 })
 describe('fork values support', () => {
   test('values as js Map', async () => {
-    const app = createDomain()
-
-    const logsCache = app.createStore<string[]>([])
-    const settings = app.createStore({
+    const logsCache = createStore<string[]>([])
+    const settings = createStore({
       MAX_COUNT_CACHED_LOGS: 12,
     })
 
-    const scope = fork(app, {
+    const scope = fork({
       values: new Map()
         .set(settings, {MAX_COUNT_CACHED_LOGS: 2})
         .set(logsCache, ['LOG_MSG_MOCK']),
@@ -201,14 +181,12 @@ describe('fork values support', () => {
     expect(scope.getState(logsCache)).toEqual(['LOG_MSG_MOCK'])
   })
   test('values as tuple list', async () => {
-    const app = createDomain()
-
-    const logsCache = app.createStore<string[]>([])
-    const settings = app.createStore({
+    const logsCache = createStore<string[]>([])
+    const settings = createStore({
       MAX_COUNT_CACHED_LOGS: 12,
     })
 
-    const scope = fork(app, {
+    const scope = fork({
       values: [
         [settings, {MAX_COUNT_CACHED_LOGS: 2}],
         [logsCache, ['LOG_MSG_MOCK']],
@@ -219,14 +197,12 @@ describe('fork values support', () => {
     expect(scope.getState(logsCache)).toEqual(['LOG_MSG_MOCK'])
   })
   test('values as sid map', async () => {
-    const app = createDomain()
-
-    const logsCache = app.createStore([])
-    const settings = app.createStore({
+    const logsCache = createStore([])
+    const settings = createStore({
       MAX_COUNT_CACHED_LOGS: 12,
     })
 
-    const scope = fork(app, {
+    const scope = fork({
       values: {
         [logsCache.sid!]: ['LOG_MSG_MOCK'],
         [settings.sid!]: {MAX_COUNT_CACHED_LOGS: 2},
@@ -244,10 +220,9 @@ describe('fork values support', () => {
     }).toThrowErrorMatchingInlineSnapshot(`"Map key should be a unit"`)
   })
   test('passed non store to values map should throw', () => {
-    const app = createDomain()
     const unit = createEvent()
     expect(() => {
-      fork(app, {
+      fork({
         values: new Map().set(unit, 0),
       })
     }).toThrowErrorMatchingInlineSnapshot(

--- a/src/effector/__tests__/fork/index.test.ts
+++ b/src/effector/__tests__/fork/index.test.ts
@@ -707,30 +707,6 @@ describe('no-scope events should not affect scoped stores', () => {
   })
 })
 
-describe(`fork(domain) and related api's are deprecated`, () => {
-  let warn: jest.SpyInstance<void, [message?: any, ...optionalParams: any[]]>
-  beforeEach(() => {
-    warn = jest.spyOn(console, 'error').mockImplementation(() => {})
-  })
-  afterEach(() => {
-    warn.mockRestore()
-  })
-
-  function getWarning() {
-    return warn.mock.calls.map(([msg]) => msg).join('\n')
-  }
-
-  test('fork(domain) is deprecated', () => {
-    const d = createDomain()
-
-    fork(d)
-
-    expect(getWarning()).toMatchInlineSnapshot(
-      `"fork(domain) is deprecated, use fork() instead"`,
-    )
-  })
-})
-
 describe('babel-plugin-update', () => {
   test('patronum 19 doesn not blows up', () => {
     expect(() => {

--- a/src/effector/__tests__/fork/serialize.test.ts
+++ b/src/effector/__tests__/fork/serialize.test.ts
@@ -13,8 +13,6 @@ import {
 } from 'effector'
 import {muteErrors} from 'effector/fixtures'
 
-muteErrors(['fork(domain)'])
-
 it('serialize stores to object of sid as keys', () => {
   const $a = createStore('value', {sid: 'a'})
   const $b = createStore([], {sid: 'b'})
@@ -200,7 +198,7 @@ it('serialize stores in nested domain', () => {
   const $c = third.createStore(null as null | number, {sid: 'c'})
   const $d = app.createStore(false, {sid: 'd'})
 
-  const scope = fork(app, {
+  const scope = fork({
     values: [
       [$a, 'value2'],
       [$b, []],

--- a/src/effector/__tests__/fork/serialize.test.ts
+++ b/src/effector/__tests__/fork/serialize.test.ts
@@ -13,7 +13,7 @@ import {
 } from 'effector'
 import {muteErrors} from 'effector/fixtures'
 
-muteErrors(['onlyChanges', 'fork(domain)'])
+muteErrors(['fork(domain)'])
 
 it('serialize stores to object of sid as keys', () => {
   const $a = createStore('value', {sid: 'a'})
@@ -214,313 +214,120 @@ it('serialize stores in nested domain', () => {
   })
 })
 
-describe('onlyChanges: true', () => {
-  it('avoid serializing combined stores when they are not changed', async () => {
-    const newMessage = createEvent()
-    const messages = createStore(0, {sid: 'messages'}).on(
-      newMessage,
-      x => x + 1,
-    )
-    const stats = combine({messages})
-    const scope = fork()
-    expect(serialize(scope)).toEqual({})
-    await allSettled(newMessage, {scope})
-    expect(serialize(scope)).toEqual({messages: 1})
-  })
-  it('skip unchanged objects', async () => {
-    const newMessage = createEvent()
-    const messages = createStore(0, {sid: 'messages'}).on(
-      newMessage,
-      x => x + 1,
-    )
-    const scope = fork()
-    expect(serialize(scope)).toEqual({})
-    await allSettled(newMessage, {scope})
-    expect(serialize(scope)).toEqual({messages: 1})
-  })
-
-  it('keep store in serialization when it returns to default state', async () => {
-    const newMessage = createEvent()
-    const resetMessages = createEvent()
-    const messages = createStore(0, {sid: 'messages'})
-      .on(newMessage, x => x + 1)
-      .reset(resetMessages)
-    const scope = fork()
-    await allSettled(newMessage, {scope})
-    await allSettled(resetMessages, {scope})
-    expect(serialize(scope)).toEqual({messages: 0})
-  })
-  it('keep store in serialization when it filled with fork values', async () => {
-    const newMessage = createEvent()
-    const resetMessages = createEvent()
-    const messages = createStore(0, {sid: 'messages'})
-      .on(newMessage, x => x + 1)
-      .reset(resetMessages)
-    const scope = fork({
-      values: [[messages, 1]],
-    })
-    expect(serialize(scope)).toEqual({messages: 1})
-    await allSettled(resetMessages, {scope})
-    expect(serialize(scope)).toEqual({messages: 0})
-  })
-
-  describe('serializing combine', () => {
-    it('should not serialize combine in default case', async () => {
-      const trigger = createEvent()
-      const foo = createStore(0, {sid: 'foo'}).on(trigger, x => x + 1)
-      const bar = createStore(0, {sid: 'bar'}).on(trigger, x => x + 1)
-      const combined = combine({foo, bar})
-      const scope = fork()
-      await allSettled(trigger, {scope})
-      expect(serialize(scope)).toEqual({foo: 1, bar: 1})
-    })
-    describe('don`t reuse values from user', () => {
-      test('with sample (more convenient)', async () => {
-        const triggerA = createEvent()
-        const triggerB = createEvent()
-        const foo = createStore(0, {sid: 'foo'})
-        const bar = createStore(0, {sid: 'bar'}).on(triggerB, x => x + 10)
-        const combined = createStore({foo: 0, bar: 0}).on(
-          combine({foo, bar}),
-          (_, x) => x,
-        )
-        sample({
-          clock: triggerA,
-          source: combined,
-          target: combined,
-          fn: ({foo, bar}) => ({
-            foo: foo + 1,
-            bar: bar + 1,
-          }),
-        })
-
-        const sid = String(combined.sid)
-
-        const scope = fork()
-        await allSettled(triggerA, {scope})
-        expect(serialize(scope)).toEqual({[sid]: {foo: 1, bar: 1}})
-        await allSettled(triggerB, {scope})
-        expect(serialize(scope)).toEqual({bar: 10, [sid]: {foo: 0, bar: 10}})
-        await allSettled(triggerA, {scope})
-        expect(serialize(scope)).toEqual({bar: 10, [sid]: {foo: 1, bar: 11}})
-        await allSettled(triggerB, {scope})
-        expect(serialize(scope)).toEqual({bar: 20, [sid]: {foo: 0, bar: 20}})
-      })
-      test('with on (less convenient)', async () => {
-        const warn = jest.spyOn(console, 'error').mockImplementation(() => {})
-        const triggerA = createEvent()
-        const triggerB = createEvent()
-        const foo = createStore(0, {sid: 'foo'})
-        const bar = createStore(0, {sid: 'bar'}).on(triggerB, x => x + 10)
-        const combined = createStore({foo: 0, bar: 0}).on(
-          combine({foo, bar}),
-          (_, x) => x,
-        )
-        combined.on(triggerA, ({foo, bar}) => ({
-          foo: foo + 1,
-          bar: bar + 1,
-        }))
-        warn.mockRestore()
-
-        const sid = String(combined.sid)
-
-        const scope = fork()
-        await allSettled(triggerA, {scope})
-        expect(serialize(scope)).toEqual({[sid]: {foo: 1, bar: 1}})
-        await allSettled(triggerB, {scope})
-        expect(serialize(scope)).toEqual({bar: 10, [sid]: {foo: 0, bar: 10}})
-        await allSettled(triggerA, {scope})
-        expect(serialize(scope)).toEqual({bar: 10, [sid]: {foo: 1, bar: 11}})
-        await allSettled(triggerB, {scope})
-        expect(serialize(scope)).toEqual({bar: 20, [sid]: {foo: 0, bar: 20}})
-      })
-    })
-  })
-
-  test('serialize: ignore', async () => {
-    const app = createDomain()
-    const inc = app.createEvent()
-    const $a = app.createStore(0, {sid: 'a', serialize: 'ignore'})
-    const $b = app.createStore(0, {sid: 'b'})
-    $a.on(inc, x => x + 1)
-    $b.on(inc, x => x + 1)
-
-    const scope = fork(app)
-
-    await allSettled(inc, {scope})
-
-    expect(serialize(scope, {onlyChanges: false})).toEqual({b: 1})
-  })
-})
-
-describe('onlyChanges: false', () => {
-  it('avoid serializing combined stores when they are not changed', async () => {
-    const app = createDomain()
-    const newMessage = app.createEvent()
-    const messages = app
-      .createStore(0, {sid: 'messages'})
-      .on(newMessage, x => x + 1)
-    const stats = combine({messages})
-    const scope = fork(app)
-    expect(serialize(scope, {onlyChanges: false})).toEqual({messages: 0})
-    await allSettled(newMessage, {scope})
-    expect(serialize(scope, {onlyChanges: false})).toEqual({messages: 1})
-  })
-  it('keep unchanged objects', async () => {
-    const app = createDomain()
-    const newMessage = app.createEvent()
-    const messages = app
-      .createStore(0, {sid: 'messages'})
-      .on(newMessage, x => x + 1)
-    const scope = fork(app)
-    expect(serialize(scope, {onlyChanges: false})).toEqual({messages: 0})
-    await allSettled(newMessage, {scope})
-    expect(serialize(scope, {onlyChanges: false})).toEqual({messages: 1})
-  })
-
-  it('keep store in serialization when it returns to default state', async () => {
-    const app = createDomain()
-    const newMessage = app.createEvent()
-    const resetMessages = app.createEvent()
-    const messages = app
-      .createStore(0, {sid: 'messages'})
-      .on(newMessage, x => x + 1)
-      .reset(resetMessages)
-    const scope = fork(app)
-    await allSettled(newMessage, {scope})
-    await allSettled(resetMessages, {scope})
-    expect(serialize(scope, {onlyChanges: false})).toEqual({messages: 0})
-  })
-  it('keep store in serialization when it filled with fork values', async () => {
-    const app = createDomain()
-    const newMessage = app.createEvent()
-    const resetMessages = app.createEvent()
-    const messages = app
-      .createStore(0, {sid: 'messages'})
-      .on(newMessage, x => x + 1)
-      .reset(resetMessages)
-    const scope = fork(app, {
-      values: [[messages, 1]],
-    })
-    expect(serialize(scope, {onlyChanges: false})).toEqual({messages: 1})
-    await allSettled(resetMessages, {scope})
-    expect(serialize(scope, {onlyChanges: false})).toEqual({messages: 0})
-  })
-
-  describe('serializing combine', () => {
-    it('should not serialize combine in default case', async () => {
-      const app = createDomain()
-      const trigger = app.createEvent()
-      const foo = app.createStore(0, {sid: 'foo'}).on(trigger, x => x + 1)
-      const bar = app.createStore(0, {sid: 'bar'}).on(trigger, x => x + 1)
-      const combined = combine({foo, bar})
-      const scope = fork(app)
-      await allSettled(trigger, {scope})
-      expect(serialize(scope, {onlyChanges: false})).toEqual({foo: 1, bar: 1})
-    })
-    describe('don`t reuse values from user', () => {
-      test('with sample (more convenient)', async () => {
-        const app = createDomain()
-        const triggerA = app.createEvent()
-        const triggerB = app.createEvent()
-        const foo = app.createStore(0, {sid: 'foo'})
-        const bar = app.createStore(0, {sid: 'bar'}).on(triggerB, x => x + 10)
-        const combined = createStore({foo: 0, bar: 0}).on(
-          combine({foo, bar}),
-          (_, x) => x,
-        )
-        sample({
-          clock: triggerA,
-          source: combined,
-          target: combined,
-          fn: ({foo, bar}) => ({
-            foo: foo + 1,
-            bar: bar + 1,
-          }),
-        })
-
-        const sid = String(combined.sid)
-
-        const scope = fork(app)
-        await allSettled(triggerA, {scope})
-        expect(serialize(scope, {onlyChanges: false})).toEqual({
-          foo: 0,
-          bar: 0,
-          [sid]: {foo: 1, bar: 1},
-        })
-        await allSettled(triggerB, {scope})
-        expect(serialize(scope, {onlyChanges: false})).toEqual({
-          foo: 0,
-          bar: 10,
-          [sid]: {foo: 0, bar: 10},
-        })
-        await allSettled(triggerA, {scope})
-        expect(serialize(scope, {onlyChanges: false})).toEqual({
-          foo: 0,
-          bar: 10,
-          [sid]: {foo: 1, bar: 11},
-        })
-        await allSettled(triggerB, {scope})
-        expect(serialize(scope, {onlyChanges: false})).toEqual({
-          foo: 0,
-          bar: 20,
-          [sid]: {foo: 0, bar: 20},
-        })
-      })
-      test('with on (less convenient)', async () => {
-        const warn = jest.spyOn(console, 'error').mockImplementation(() => {})
-        const app = createDomain()
-        const triggerA = app.createEvent()
-        const triggerB = app.createEvent()
-        const foo = app.createStore(0, {sid: 'foo'})
-        const bar = app.createStore(0, {sid: 'bar'}).on(triggerB, x => x + 10)
-        const combined = createStore({foo: 0, bar: 0}).on(
-          combine({foo, bar}),
-          (_, x) => x,
-        )
-        combined.on(triggerA, ({foo, bar}) => ({
-          foo: foo + 1,
-          bar: bar + 1,
-        }))
-        warn.mockRestore()
-
-        const sid = String(combined.sid)
-
-        const scope = fork(app)
-        await allSettled(triggerA, {scope})
-        expect(serialize(scope, {onlyChanges: false})).toEqual({
-          foo: 0,
-          bar: 0,
-          [sid]: {foo: 1, bar: 1},
-        })
-        await allSettled(triggerB, {scope})
-        expect(serialize(scope, {onlyChanges: false})).toEqual({
-          foo: 0,
-          bar: 10,
-          [sid]: {foo: 0, bar: 10},
-        })
-        await allSettled(triggerA, {scope})
-        expect(serialize(scope, {onlyChanges: false})).toEqual({
-          foo: 0,
-          bar: 10,
-          [sid]: {foo: 1, bar: 11},
-        })
-        await allSettled(triggerB, {scope})
-        expect(serialize(scope, {onlyChanges: false})).toEqual({
-          foo: 0,
-          bar: 20,
-          [sid]: {foo: 0, bar: 20},
-        })
-      })
-    })
-  })
-})
-
-test('onlyChanges: false supported only in domain-based scopes', () => {
+it('avoid serializing combined stores when they are not changed', async () => {
+  const newMessage = createEvent()
+  const messages = createStore(0, {sid: 'messages'}).on(newMessage, x => x + 1)
+  const stats = combine({messages})
   const scope = fork()
-  expect(() => {
-    serialize(scope, {onlyChanges: false})
-  }).toThrowErrorMatchingInlineSnapshot(`"scope should be created from domain"`)
+  expect(serialize(scope)).toEqual({})
+  await allSettled(newMessage, {scope})
+  expect(serialize(scope)).toEqual({messages: 1})
+})
+it('skip unchanged objects', async () => {
+  const newMessage = createEvent()
+  const messages = createStore(0, {sid: 'messages'}).on(newMessage, x => x + 1)
+  const scope = fork()
+  expect(serialize(scope)).toEqual({})
+  await allSettled(newMessage, {scope})
+  expect(serialize(scope)).toEqual({messages: 1})
+})
+
+it('keep store in serialization when it returns to default state', async () => {
+  const newMessage = createEvent()
+  const resetMessages = createEvent()
+  const messages = createStore(0, {sid: 'messages'})
+    .on(newMessage, x => x + 1)
+    .reset(resetMessages)
+  const scope = fork()
+  await allSettled(newMessage, {scope})
+  await allSettled(resetMessages, {scope})
+  expect(serialize(scope)).toEqual({messages: 0})
+})
+it('keep store in serialization when it filled with fork values', async () => {
+  const newMessage = createEvent()
+  const resetMessages = createEvent()
+  const messages = createStore(0, {sid: 'messages'})
+    .on(newMessage, x => x + 1)
+    .reset(resetMessages)
+  const scope = fork({
+    values: [[messages, 1]],
+  })
+  expect(serialize(scope)).toEqual({messages: 1})
+  await allSettled(resetMessages, {scope})
+  expect(serialize(scope)).toEqual({messages: 0})
+})
+
+describe('serializing combine', () => {
+  it('should not serialize combine in default case', async () => {
+    const trigger = createEvent()
+    const foo = createStore(0, {sid: 'foo'}).on(trigger, x => x + 1)
+    const bar = createStore(0, {sid: 'bar'}).on(trigger, x => x + 1)
+    const combined = combine({foo, bar})
+    const scope = fork()
+    await allSettled(trigger, {scope})
+    expect(serialize(scope)).toEqual({foo: 1, bar: 1})
+  })
+  describe('don`t reuse values from user', () => {
+    test('with sample (more convenient)', async () => {
+      const triggerA = createEvent()
+      const triggerB = createEvent()
+      const foo = createStore(0, {sid: 'foo'})
+      const bar = createStore(0, {sid: 'bar'}).on(triggerB, x => x + 10)
+      const combined = createStore({foo: 0, bar: 0}).on(
+        combine({foo, bar}),
+        (_, x) => x,
+      )
+      sample({
+        clock: triggerA,
+        source: combined,
+        target: combined,
+        fn: ({foo, bar}) => ({
+          foo: foo + 1,
+          bar: bar + 1,
+        }),
+      })
+
+      const sid = String(combined.sid)
+
+      const scope = fork()
+      await allSettled(triggerA, {scope})
+      expect(serialize(scope)).toEqual({[sid]: {foo: 1, bar: 1}})
+      await allSettled(triggerB, {scope})
+      expect(serialize(scope)).toEqual({bar: 10, [sid]: {foo: 0, bar: 10}})
+      await allSettled(triggerA, {scope})
+      expect(serialize(scope)).toEqual({bar: 10, [sid]: {foo: 1, bar: 11}})
+      await allSettled(triggerB, {scope})
+      expect(serialize(scope)).toEqual({bar: 20, [sid]: {foo: 0, bar: 20}})
+    })
+    test('with on (less convenient)', async () => {
+      const warn = jest.spyOn(console, 'error').mockImplementation(() => {})
+      const triggerA = createEvent()
+      const triggerB = createEvent()
+      const foo = createStore(0, {sid: 'foo'})
+      const bar = createStore(0, {sid: 'bar'}).on(triggerB, x => x + 10)
+      const combined = createStore({foo: 0, bar: 0}).on(
+        combine({foo, bar}),
+        (_, x) => x,
+      )
+      combined.on(triggerA, ({foo, bar}) => ({
+        foo: foo + 1,
+        bar: bar + 1,
+      }))
+      warn.mockRestore()
+
+      const sid = String(combined.sid)
+
+      const scope = fork()
+      await allSettled(triggerA, {scope})
+      expect(serialize(scope)).toEqual({[sid]: {foo: 1, bar: 1}})
+      await allSettled(triggerB, {scope})
+      expect(serialize(scope)).toEqual({bar: 10, [sid]: {foo: 0, bar: 10}})
+      await allSettled(triggerA, {scope})
+      expect(serialize(scope)).toEqual({bar: 10, [sid]: {foo: 1, bar: 11}})
+      await allSettled(triggerB, {scope})
+      expect(serialize(scope)).toEqual({bar: 20, [sid]: {foo: 0, bar: 20}})
+    })
+  })
 })
 
 describe('serialize: missing sids', () => {

--- a/src/effector/fork/createScope.ts
+++ b/src/effector/fork/createScope.ts
@@ -2,12 +2,12 @@ import {getForkPage, getGraph} from '../getter'
 import {setForkPage, getPageRef, currentPage} from '../kernel'
 import {createNode} from '../createNode'
 import {calc, compute} from '../step'
-import type {Domain, Scope, SettledDefer, Store} from '../unit.h'
+import type {Scope, SettledDefer, Store} from '../unit.h'
 import type {Stack, StateRef} from '../index.h'
 import {forEach} from '../collection'
 import {DOMAIN, SAMPLER, SCOPE} from '../tag'
 
-export function createScope(unit?: Domain): Scope {
+export function createScope(): Scope {
   const forkInFlightCounter = createNode({
     scope: {
       defers: [],
@@ -95,7 +95,6 @@ export function createScope(unit?: Domain): Scope {
     ],
   })
   const resultScope: Scope = {
-    cloneOf: unit,
     reg: page,
     values: {sidMap: {}, idMap: {}},
     sidIdMap: {},

--- a/src/effector/fork/fork.ts
+++ b/src/effector/fork/fork.ts
@@ -11,26 +11,18 @@ type ForkConfig = {
   handlers?: HandlersMap
 }
 
-export function fork(
-  domainOrConfig?: Domain | ForkConfig,
-  optionalConfig?: ForkConfig,
-) {
-  let config: ForkConfig | void = domainOrConfig as any
-  let domain: Domain
-  if (is.domain(domainOrConfig)) {
-    deprecate(false, 'fork(domain)', 'fork()')
-    domain = domainOrConfig
-    config = optionalConfig
-  }
-
-  const scope = createScope(domain!)
+export function fork(config?: ForkConfig) {
+  const scope = createScope()
 
   if (config) {
     if (config.values) {
       const {sidMap, unitMap, hasSidDoubles} = normalizeValues(
         config.values,
-        unit => 
-          assert(is.store(unit) && is.targetable(unit), 'Values map can contain only writable stores as keys'),
+        unit =>
+          assert(
+            is.store(unit) && is.targetable(unit),
+            'Values map can contain only writable stores as keys',
+          ),
       )
       Object.assign(scope.values.sidMap, sidMap)
       forEach(unitMap, (value, unit) => {
@@ -39,7 +31,7 @@ export function fork(
         /**
          * If store values were provided as tuple or map,
          * but unit has sid anyway, we should add it to sidIdMap,
-         * 
+         *
          * It is needed to avoid issues, if there are duplicated sids in the code + values is a tuple or map
          */
         scope.sidIdMap[getMeta(unit, 'sid')] = (unit as Store<any>).stateRef.id

--- a/src/effector/fork/serialize.ts
+++ b/src/effector/fork/serialize.ts
@@ -1,8 +1,6 @@
 import type {Scope, Store} from '../unit.h'
 import {forIn, includes} from '../collection'
-import {assert, deprecate} from '../throw'
-import {traverseStores} from './util'
-import {getGraph, getMeta} from '../getter'
+import {assert} from '../throw'
 
 const noopSerializer = (x: any) => x
 /**
@@ -10,7 +8,7 @@ const noopSerializer = (x: any) => x
  */
 export function serialize(
   scope: Scope,
-  config: {ignore?: Array<Store<any>>; onlyChanges?: boolean} = {},
+  config: {ignore?: Array<Store<any>>} = {},
 ) {
   if (scope.warnSerialize) {
     console.error(
@@ -36,20 +34,5 @@ export function serialize(
       result[sid] = serializer(value)
     }
   })
-  if ('onlyChanges' in config) {
-    deprecate(false, 'onlyChanges')
-    if (!config.onlyChanges) {
-      assert(scope.cloneOf, 'scope should be created from domain')
-      traverseStores(getGraph(scope.cloneOf), (node, sid) => {
-        if (
-          !(sid in result) &&
-          !includes(ignoredStores, sid) &&
-          !getMeta(node, 'isCombine') &&
-          getMeta(node, 'serialize') !== 'ignore'
-        )
-          result[sid] = scope.getState(node as any)
-      })
-    }
-  }
   return result
 }

--- a/src/effector/unit.h.ts
+++ b/src/effector/unit.h.ts
@@ -166,7 +166,6 @@ export interface Scope extends Unit {
   kind: Kind
   graphite: Node
   reg: Record<string, StateRef>
-  cloneOf?: Domain
   getState<T>(store: Store<T>): T
   getState(ref: StateRef): unknown
   values: {

--- a/src/forest/__tests__/ssr/index.test.ts
+++ b/src/forest/__tests__/ssr/index.test.ts
@@ -13,9 +13,6 @@ import {renderStatic} from 'forest/server'
 import prettyHtml from 'effector/fixtures/prettyHtml'
 //@ts-expect-error
 import {provideGlobals} from 'effector/fixtures/dom'
-import {muteErrors} from 'effector/fixtures'
-
-muteErrors(['fork(domain)'])
 
 test('fork support', async () => {
   const fetchContent = createEffect(async () => {

--- a/src/react/__tests__/base/scopes.test.tsx
+++ b/src/react/__tests__/base/scopes.test.tsx
@@ -24,7 +24,7 @@ import {
   useUnit,
 } from 'effector-react'
 
-muteErrors(['fork(domain)', 'No scope found', 'AppFail'])
+muteErrors(['No scope found', 'AppFail'])
 
 async function request(url: string) {
   const users: Record<string, {name: string; friends: string[]}> = {
@@ -525,7 +525,7 @@ describe('useStoreMap', () => {
       </Provider>
     )
 
-    const scope = fork(app)
+    const scope = fork()
     await render(<App root={scope} />)
     expect(container.firstChild).toMatchInlineSnapshot(`
       <div>

--- a/src/solid/__tests__/scopes.test.tsx
+++ b/src/solid/__tests__/scopes.test.tsx
@@ -1,5 +1,4 @@
 import {render} from 'solid-testing-library'
-import {argumentHistory, muteErrors} from 'effector/fixtures'
 import {
   createDomain,
   createEvent,
@@ -13,8 +12,6 @@ import {
 } from 'effector'
 import {Provider, useUnit, useGate, createGate} from 'effector-solid'
 import {createSignal} from 'solid-js'
-
-muteErrors(['fork(domain)'])
 
 async function request(url: string) {
   const users: Record<string, {name: string; friends: string[]}> = {
@@ -69,7 +66,7 @@ test('computed values support', async () => {
     </Provider>
   )
 
-  const serverScope = fork(app)
+  const serverScope = fork()
   await allSettled(start, {
     scope: serverScope,
     params: 'alice',

--- a/src/types/__tests__/effector/fork.test.ts
+++ b/src/types/__tests__/effector/fork.test.ts
@@ -237,16 +237,12 @@ describe('fork values', () => {
 
       expect(typecheck).toMatchInlineSnapshot(`
         "
-        No overload matches this call.
-          Overload 1 of 2, '(config?: { values?: SerializedState | LegacyMap | StorePair<any>[] | undefined; handlers?: Handlers | undefined; } | undefined): Scope', gave the following error.
-            Type '([StoreWritable<string>, string] | [Store<number>, number] | [StoreWritable<{ nested: { value: number; }; }>, { nested: { value: number; }; }])[]' is not assignable to type 'SerializedState | LegacyMap | StorePair<any>[] | undefined'.
-              Type '([StoreWritable<string>, string] | [Store<number>, number] | [StoreWritable<{ nested: { value: number; }; }>, { nested: { value: number; }; }])[]' is not assignable to type 'StorePair<any>[]'.
-                Type '[StoreWritable<string>, string] | [Store<number>, number] | [StoreWritable<{ nested: { value: number; }; }>, { nested: { value: number; }; }]' is not assignable to type 'StorePair<any>'.
-                  Type '[Store<number>, number]' is not assignable to type '[StoreWritable<any>, any]'.
-                    Type at position 0 in source is not compatible with type at position 0 in target.
-                      Type 'Store<number>' is missing the following properties from type 'StoreWritable<any>': ____, on, off, reset, and 2 more.
-          Overload 2 of 2, '(domain: Domain, config?: { values?: [StoreWritable<any>, any][] | SerializedState | LegacyMap | undefined; handlers?: Handlers | undefined; } | undefined): Scope', gave the following error.
-            Object literal may only specify known properties, and 'values' does not exist in type 'Domain'.
+        Type '([StoreWritable<string>, string] | [Store<number>, number] | [StoreWritable<{ nested: { value: number; }; }>, { nested: { value: number; }; }])[]' is not assignable to type 'SerializedState | LegacyMap | StorePair<any>[] | undefined'.
+          Type '([StoreWritable<string>, string] | [Store<number>, number] | [StoreWritable<{ nested: { value: number; }; }>, { nested: { value: number; }; }])[]' is not assignable to type 'StorePair<any>[]'.
+            Type '[StoreWritable<string>, string] | [Store<number>, number] | [StoreWritable<{ nested: { value: number; }; }>, { nested: { value: number; }; }]' is not assignable to type 'StorePair<any>'.
+              Type '[Store<number>, number]' is not assignable to type '[StoreWritable<any>, any]'.
+                Type at position 0 in source is not compatible with type at position 0 in target.
+                  Type 'Store<number>' is missing the following properties from type 'StoreWritable<any>': ____, on, off, reset, and 2 more.
         "
       `)
     })


### PR DESCRIPTION
- Delete deprecated `fork(domain)` overload
- Delete deprecated option `onlyChanges` in `fork` function