### PR TITLE
No magic import effector-react ESM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ See also [separate changelogs for each library](https://changelog.effector.dev/)
 
 - Delete deprecated `effector-react/scope` in favor of isomorphic hooks ([PR #1084](https://github.com/effector/effector/pull/1084))
 - Delete deprecated `useStore`, `useEvent`, `connect`, `createComponent` and `createStoreConsumer` in favor of universal `useUnit` ([PR #1088](https://github.com/effector/effector/pull/1088))
+- Use regular import of `effector` in ESM version of `effector-react` ([PR #1096](https://github.com/effector/effector/pull/1096))
 
 ## effector-solid 24.0.0
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -41,7 +41,7 @@ const jsdomTestPlugin = resolvePath(
 const aliases = {
   'effector/fixtures': resolveFromSources('fixtures'),
   'effector-react': {
-    esm: 'effector-react/effector-react.mjs',
+    esm: null,
     compat: 'effector-react/compat',
     build: null,
     test: null,
@@ -51,7 +51,7 @@ const aliases = {
   'effector-solid': resolveFromSources('solid'),
   Builder: resolveFromSources('../tools/builder'),
   effector: {
-    esm: 'effector/effector.mjs',
+    esm: null,
     compat: 'effector/compat',
     build: null,
     test: null,


### PR DESCRIPTION
fixes #879

- Use regular import of `effector` in ESM version of `effector-react`

This hack is presented only in `effector-react`, other bindings (`effector-vue` and `effector-solid`) works correctly without it. So, in #879 we've decided to remove it.

The solution is tested against playground-app in https://github.com/effector/next. I edited file `effector-react/effector-react.mjs` in `node_modules` of `playground_app`, cleaned `.next` and started the application, it is working as usual.