### PR TITLE
Mark `useStore` in `effector-vue` as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ See also [separate changelogs for each library](https://changelog.effector.dev/)
 - Delete deprecated `effector-vue/ssr` in favor of isomorphic hooks ([PR #1084](https://github.com/effector/effector/pull/1084))
 - Delete deprecated `VueSSRPlugin` in favor of `EffectorScopePlugin` ([PR #1084](https://github.com/effector/effector/pull/1084))
 - Drop support for UMD build ([PR #1097](https://github.com/effector/effector/pull/1097))
+- Function `useStore` is deprecated in favor of `useUnit` ([PR #1099](https://github.com/effector/effector/pull/1099))
 
 ## forest 0.22.0
 

--- a/documentation/src/content/docs/en/api/effector-vue/useEvent.md
+++ b/documentation/src/content/docs/en/api/effector-vue/useEvent.md
@@ -5,50 +5,8 @@ redirectFrom:
   - /docs/api/effector-vue/useEvent
 ---
 
-```ts
-import { useEvent } from "effector-vue/composition";
-```
+:::warning{title="Deleted"}
+Since [effector 24.0.0](https://changelog.effector.dev/#effector-24-0-0) this method was removed.
 
-:::warning{title="Deprecated"}
-Since [effector 23.0.0](https://changelog.effector.dev/#effector-23-0-0) `useEvent` is deprecated. Use [`useUnit`](./useUnit#useUnit) instead.
+To read documentation for this method, please refer to [the documentation for the version of effector-vue that was released before 24.0.0](https://v23.effector.dev/en/api/effector-vue/useEvent/).
 :::
-
-Bind event to current fork instance to use in dom event handlers.
-
-# Methods (#methods)
-
-## `useEvent(unit)` (#methods-useEvent-unit)
-
-### Arguments (#methods-useEvent-unit-arguments)
-
-1. `unit` ([_Event_](/en/api/effector/Event) or [_Effect_](/en/api/effector/Effect)): Event or effect which will be bound to current `scope`
-
-### Returns (#methods-useEvent-unit-returns)
-
-(`Function`): Function to pass to event handlers. Will trigger a given unit in current scope
-
-### Examples (#methods-useEvent-unit-examples)
-
-#### Basic (#methods-useEvent-unit-examples-basic)
-
-```js
-import { createStore, createEvent } from "effector";
-import { useEvent } from "effector-vue/composition";
-
-const incremented = createEvent();
-const $count = createStore(0);
-
-$count.on(incremented, (x) => x + 1);
-
-export default {
-  setup() {
-    const counter = useStore($count);
-    const onIncrement = useEvent(incremented);
-
-    return {
-      onIncrement,
-      counter,
-    };
-  },
-};
-```

--- a/documentation/src/content/docs/en/api/effector-vue/useStore.md
+++ b/documentation/src/content/docs/en/api/effector-vue/useStore.md
@@ -6,6 +6,12 @@ redirectFrom:
   - /docs/api/effector-vue/useStore
 ---
 
+:::warning{title="Deprecated"}
+since [effector-vue 24.0.0](https://changelog.effector.dev/#effector-vue-24-0-0).
+
+Consider using [`useUnit`](/en/api/effector-vue/useUnit) instead.
+:::
+
 ```ts
 import { useStore } from "effector-vue/composition";
 ```

--- a/documentation/src/content/docs/en/api/effector-vue/useUnit.md
+++ b/documentation/src/content/docs/en/api/effector-vue/useUnit.md
@@ -13,16 +13,6 @@ Bind [_Stores_](../effector/Store) to Vue reactivity system or, in the case of [
 
 **Designed for Vue 3 and Composition API exclusively.**
 
-:::info{title="Future"}
-This API can completely replace the following APIs:
-
-- [useStore($store)](./useStore)
-- [useEvent(event)](./useEvent)
-
-In the future, these APIs can be deprecated and removed.
-
-:::
-
 # Methods (#methods)
 
 ## `useUnit(unit)` (#methods-useUnit-unit)

--- a/documentation/src/content/docs/en/guides/migration-guide-v24.md
+++ b/documentation/src/content/docs/en/guides/migration-guide-v24.md
@@ -18,3 +18,33 @@ The UMD (Universal Module Definition) version of all packages (`effector`, `effe
 The UMD pattern typically attempts to offer compatibility with the most popular script loaders (e.g RequireJS amongst others). However, in 2024 all modern build tools (and browsers) support ES modules, so there is no need to support UMD.
 
 In case you have to use UMD build for some reason, you can use the ES module version of the package and transpile it to UMD during your build process.
+
+## `effector-vue`
+
+A couple of breaking changes were introduced in `effector-vue` package as well.
+
+### `useStore` is deprecated
+
+`useStore` is deprecated in favor of [`useUnit`](/en/api/effector-solid/useUnit). It will be removed in the next major version of `effector-vue`.
+
+You can replace `useStore` with [`useUnit`](/en/api/effector-solid/useUnit) like this:
+
+```diff
+- import {useStore} from 'effector-vue/composition';
++ import {useUnit} from 'effector-vue/composition';
+
+- const value = useStore($store);
++ const value = useUnit($store);
+```
+
+Bonus: `useUnit` is more flexible and can be used with any unit, not only stores.
+
+```ts
+import { useUnit } from "effector-vue/composition";
+
+const { value, error, onChange } = useUnit({
+  value: $value,
+  error: $error,
+  onChange: changeValue,
+});
+```

--- a/packages/effector-vue/composition.d.ts
+++ b/packages/effector-vue/composition.d.ts
@@ -39,6 +39,9 @@ export function useVModel<T>(vm: Store<T>): Ref<UnwrapRef<T>>
 export function useVModel<T extends Record<string, Store<any>>>(
   vm: T,
 ): ExtractStore<T>
+/**
+ * @deprecated since v24.0.0, use useUnit instead
+ */
 export function useStore<T>(store: Store<T>): DeepReadonly<Ref<T>>
 export function createGate<Props>(config?: GateConfig<Props>): Gate<Props>
 export function useGate<Props>(

--- a/src/vue/lib/useDeprecate.ts
+++ b/src/vue/lib/useDeprecate.ts
@@ -1,0 +1,17 @@
+import {onMounted} from 'vue-next'
+
+export function useDeprecate(
+  cond: boolean,
+  subject: string,
+  useInstead?: string,
+) {
+  onMounted(() => {
+    if (cond) {
+      console.error(
+        `${subject} is deprecated${
+          useInstead ? `, prefer ${useInstead} instead` : ''
+        }`,
+      )
+    }
+  })
+}

--- a/src/vue/useStore.ts
+++ b/src/vue/useStore.ts
@@ -4,8 +4,10 @@ import {onUnmounted, readonly, shallowRef} from 'vue-next'
 import {stateReader} from './lib/state-reader'
 import {getScope} from './lib/get-scope'
 import {throwError} from './lib/throw'
+import {useDeprecate} from './lib/useDeprecate'
 
 export function useStore<T>(store: Store<T>) {
+  useDeprecate(true, 'useStore', 'useUnit')
   if (!is.store(store)) throwError('expect useStore argument to be a store')
   let {scope} = getScope()
 


### PR DESCRIPTION
- Function `useStore` is deprecated in favor of `useUnit`
- Issue about future deletion https://github.com/effector/effector/issues/1100