### PR TITLE
Delete plain object as handlers deprecated overload in fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See also [separate changelogs for each library](https://changelog.effector.dev/)
 - Delete deprecated option `onlyChanges` in `fork` function ([PR #1092](https://github.com/effector/effector/pull/1092))
 - Delete broken `setStoreName` function ([PR #1094](https://github.com/effector/effector/pull/1094))
 - Drop support for UMD build ([PR #1097](https://github.com/effector/effector/pull/1097))
+- Delete deprecated `fork({ handlers: sidMap })` overload ([PR #1102](https://github.com/effector/effector/pull/1102))
 
 ## effector-react 24.0.0
 

--- a/documentation/src/content/docs/en/api/effector/fork.md
+++ b/documentation/src/content/docs/en/api/effector/fork.md
@@ -148,23 +148,6 @@ fork({
 });
 ```
 
-3.  Plain object: `{[sid: string]: handler}`
-
-```ts
-fork({
-  handlers: {
-    [getMessageFx.sid]: (params) => ({ id: 0, text: "message" }),
-    [getUserFx.sid]: async (params) => ({ name: "alice", age: 21 }),
-  },
-});
-```
-
-<br />
-
-:::warning{title="deprecation"}
-Such objects are deprecated since [effector 23.0.0](https://changelog.effector.dev/#effector-23-0-0) and will be removed in future versions. Array of tuples is preferred.
-:::
-
 ### Returns (#methods-fork-options-returns)
 
 [_Scope_](/en/api/effector/Scope): New fresh scope

--- a/src/effector/__tests__/fork/fork.test.ts
+++ b/src/effector/__tests__/fork/fork.test.ts
@@ -471,24 +471,6 @@ describe('fork handlers support', () => {
 
     expect(scope.getState(acc)).toEqual(['fn'])
   })
-  test('handlers as sid map', async () => {
-    const fx = createEffect(() => 'not to call')
-
-    const acc = createStore<string[]>([]).on(fx.doneData, (list, val) => [
-      ...list,
-      val,
-    ])
-
-    const scope = fork({
-      handlers: {
-        [fx.sid!]: () => 'fn',
-      },
-    })
-
-    await allSettled(fx, {scope})
-
-    expect(scope.getState(acc)).toEqual(['fn'])
-  })
   test('handlers as a tuple list, but with sid doubles', async () => {
     const h1 = jest.fn()
     const h2 = jest.fn()

--- a/src/effector/createEffect.ts
+++ b/src/effector/createEffect.ts
@@ -106,9 +106,7 @@ export function createEffect<Params, Done, Fail = Error>(
           let handler: Function = scope_.handler
           const scope = getForkPage(stack)
           if (scope) {
-            const scopeHandler =
-              scope.handlers.unitMap.get(instance) ||
-              scope.handlers.sidMap[instance.sid!]
+            const scopeHandler = scope.handlers.unitMap.get(instance)
             if (scopeHandler) handler = scopeHandler
           }
           upd.handler = handler

--- a/src/effector/fork/createScope.ts
+++ b/src/effector/fork/createScope.ts
@@ -117,7 +117,7 @@ export function createScope(): Scope {
       scope: {forkInFlightCounter},
     }),
     additionalLinks: {},
-    handlers: {sidMap: {}, unitMap: new Map()},
+    handlers: {unitMap: new Map()},
     fxCount: forkInFlightCounter,
     storeChange,
     warnSerializeNode,

--- a/src/effector/unit.h.ts
+++ b/src/effector/unit.h.ts
@@ -180,7 +180,6 @@ export interface Scope extends Unit {
   >
   additionalLinks: Record<string, Node[]>
   handlers: {
-    sidMap: Record<string, (params: unknown) => any>
     /** map of sidless effects */
     unitMap: Map<Unit<any>, (params: unknown) => any>
   }

--- a/src/effector/unit.h.ts
+++ b/src/effector/unit.h.ts
@@ -201,7 +201,6 @@ export type ValuesMap =
 export type HandlersMap =
   | Map<Effect<any, any, any>, Function>
   | Array<[Effect<any, any, any>, Function]>
-  | Record<string, Function>
 
 export type Defer = {
   rs: (value: any) => any


### PR DESCRIPTION
- Delete deprecated `fork({ handlers: sidMap })` overload