### PR TITLE
remove watch from modal dialog example

### DIFF
--- a/documentation/src/content/docs/en/introduction/examples.md
+++ b/documentation/src/content/docs/en/introduction/examples.md
@@ -26,7 +26,7 @@ When we need to cancel our effect since it's pointless at the time
 
 -->
 
-### [Modal dialog](https://share.effector.dev/4ATpafwV)
+### [Modal dialog](https://share.effector.dev/8xsWOCeS)
 
 To connect react modal with state
 

--- a/documentation/src/content/docs/en/introduction/examples.md
+++ b/documentation/src/content/docs/en/introduction/examples.md
@@ -26,7 +26,7 @@ When we need to cancel our effect since it's pointless at the time
 
 -->
 
-### [Modal dialog](https://share.effector.dev/9nGj1G3z)
+### [Modal dialog](https://share.effector.dev/4ATpafwV)
 
 To connect react modal with state
 


### PR DESCRIPTION
Убрал watch из примера Модального диалога, чтобы не прививать использование watch как инструмента связки и добавил overflow: auto чтобы верно показывать диалоговое окно.

### Conventions
- [ ] Please check your messages [against the guidelines](https://cbea.ms/git-commit/) if not, perform [interactive rebase](https://thoughtbot.com/blog/git-interactive-rebase-squash-amend-rewriting-history)
- [ ] [Link an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) your pull request closes or relates
