### PR TITLE
fix: options api export from effector vue

### DIFF
--- a/documentation/src/content/docs/en/api/effector-vue/ComponentOptions.md
+++ b/documentation/src/content/docs/en/api/effector-vue/ComponentOptions.md
@@ -5,7 +5,7 @@ redirectFrom:
   - /docs/api/effector-vue/component-options
 ---
 
-# ComponentOptions (#ComponentOptions)
+# ComponentOptions (Vue2) (#ComponentOptions)
 
 ## `effector` (#ComponentOptions-effector)
 

--- a/documentation/src/content/docs/en/api/effector-vue/VueEffector.md
+++ b/documentation/src/content/docs/en/api/effector-vue/VueEffector.md
@@ -1,26 +1,24 @@
 ---
 title: VueEffector
-description: effector-vue plugin for vue 2
+description: effector-vue plugin for vue 3
 redirectFrom:
   - /api/effector-vue/VueEffector
   - /docs/api/effector-vue/vue-effector
 ---
 
 ```ts
-import { VueEffector } from "effector-vue";
+import { VueEffector } from "effector-vue/options-vue3";
 ```
 
-`effector-vue` plugin for vue 2
+`effector-vue` plugin for vue 3 creates a mixin that takes a binding function from the effector option.
 
 # Methods (#methods)
 
-## `VueEffector(Vue, options?)` (#methods-VueEffector-Vue-options)
+## `VueEffector(app)` (#methods-VueEffector-Vue-options)
 
 ### Arguments (#methods-VueEffector-Vue-options-arguments)
 
-1. `Vue` (_class Vue_): Vue class
-2. `options` (_Object_): Plugin options
-   - TBD
+1. `app` (_instance Vue_): Vue instance
 
 ### Returns (#methods-VueEffector-Vue-options-returns)
 
@@ -28,9 +26,49 @@ import { VueEffector } from "effector-vue";
 
 ### Examples (#methods-VueEffector-Vue-options-examples)
 
+#### Installation plugin
 ```js
-import Vue from "vue";
-import { VueEffector } from "effector-vue";
+import { createApp } from "vue";
+import { VueEffector } from "effector-vue/options-vue3";
 
-Vue.use(VueEffector);
+import App from './App.vue'
+
+const app = createApp(App)
+
+app.use(VueEffector);
+```
+
+#### Effector options
+```html
+<template>
+  <div>
+    <span v-if="createPending">loading...</span>
+    <p>{{ user.name }}</p>
+    ...
+    <button @click="create">Create<button>
+  </div>
+</template>
+```
+
+```js
+import { $user, create, createFx } from 'model'
+
+export default {
+  name: 'VueComponent',
+  effector: () => ({
+    user: $user,
+    createDone: createFx.done,
+    createPending: createFx.pending,
+  }),
+  watch: {
+    createDone() {
+      // do something after the effect is done
+    }
+  },
+  methods: {
+    create, // template binding
+    createFx,
+  },
+  ...
+}
 ```

--- a/documentation/src/content/docs/en/api/effector-vue/VueEffectorVue2.md
+++ b/documentation/src/content/docs/en/api/effector-vue/VueEffectorVue2.md
@@ -1,0 +1,36 @@
+---
+title: VueEffector
+description: effector-vue plugin for vue 2
+redirectFrom:
+  - /api/effector-vue/VueEffector-vue2
+  - /docs/api/effector-vue/vue-effector-vue2
+---
+
+```ts
+import { VueEffector } from "effector-vue";
+```
+
+`effector-vue` plugin for vue 2
+
+# Methods (#methods)
+
+## `VueEffector(Vue, options?)` (#methods-VueEffector-Vue-options)
+
+### Arguments (#methods-VueEffector-Vue-options-arguments)
+
+1. `Vue` (_class Vue_): Vue class
+2. `options` (_Object_): Plugin options
+  - TBD
+
+### Returns (#methods-VueEffector-Vue-options-returns)
+
+(_`void`_)
+
+### Examples (#methods-VueEffector-Vue-options-examples)
+
+```js
+import Vue from "vue";
+import { VueEffector } from "effector-vue";
+
+Vue.use(VueEffector);
+```

--- a/documentation/src/navigation.ts
+++ b/documentation/src/navigation.ts
@@ -383,11 +383,6 @@ const effectorVue: LSidebarGroup[] = [
     text: { en: "Common methods" },
     items: [
       {
-        text: { en: "VueEffector" },
-        link: "/api/effector-vue/VueEffector",
-        tags: ["useful"],
-      },
-      {
         text: { en: "EffectorScopePlugin" },
         link: "/api/effector-vue/EffectorScopePlugin",
         tags: ["useful"],
@@ -395,16 +390,6 @@ const effectorVue: LSidebarGroup[] = [
       {
         text: { en: "createComponent" },
         link: "/api/effector-vue/createComponent",
-        tags: ["useful"],
-      },
-    ],
-  },
-  {
-    text: { en: "Options and properties", uz: "Variantlar va xususiyatlar" },
-    items: [
-      {
-        text: { en: "ComponentOptions" },
-        link: "/api/effector-vue/ComponentOptions",
         tags: ["useful"],
       },
     ],
@@ -430,7 +415,7 @@ const effectorVue: LSidebarGroup[] = [
     ],
   },
   {
-    text: { en: "Hooks" },
+    text: { en: "Composition API" },
     items: [
       {
         text: { en: "useUnit" },
@@ -449,6 +434,31 @@ const effectorVue: LSidebarGroup[] = [
       {
         text: { en: "useVModel" },
         link: "/api/effector-vue/useVModel",
+        tags: ["useful"],
+      },
+    ],
+  },
+  {
+    text: { en: "Options API" },
+    items: [
+      {
+        text: { en: "VueEffector" },
+        link: "/api/effector-vue/VueEffector",
+        tags: ["useful"],
+      },
+      {
+        text: { en: "VueEffector (Vue2)" },
+        link: "/api/effector-vue/VueEffectorVue2",
+        tags: ["useful"],
+      },
+    ],
+  },
+  {
+    text: { en: "Options and properties", uz: "Variantlar va xususiyatlar" },
+    items: [
+      {
+        text: { en: "ComponentOptions (Vue2)" },
+        link: "/api/effector-vue/ComponentOptions",
         tags: ["useful"],
       },
     ],

--- a/packages/effector-vue/options-vue3.d.ts
+++ b/packages/effector-vue/options-vue3.d.ts
@@ -1,3 +1,3 @@
-import { Plugin } from 'vue-next'
+import { Plugin } from 'vue'
 
 declare function VueEffector(plugin: Plugin): void

--- a/packages/effector-vue/options-vue3.d.ts
+++ b/packages/effector-vue/options-vue3.d.ts
@@ -1,0 +1,3 @@
+import { Plugin } from 'vue-next'
+
+declare function VueEffector(plugin: Plugin): void

--- a/packages/effector-vue/options-vue3.ts
+++ b/packages/effector-vue/options-vue3.ts
@@ -1,0 +1,1 @@
+export * from '../../src/vue/optionsApi'

--- a/packages/effector-vue/package.json
+++ b/packages/effector-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effector-vue",
-  "version": "23.0.1",
+  "version": "23.0.0",
   "description": "Vue bindings for effector",
   "main": "effector-vue.cjs.js",
   "module": "effector-vue.mjs",

--- a/packages/effector-vue/package.json
+++ b/packages/effector-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effector-vue",
-  "version": "23.0.0",
+  "version": "23.0.1",
   "description": "Vue bindings for effector",
   "main": "effector-vue.cjs.js",
   "module": "effector-vue.mjs",
@@ -17,6 +17,12 @@
       "require": "./composition.cjs.js",
       "default": "./composition.mjs"
     },
+    "./options-vue3": {
+      "types": "./options-vue3.d.ts",
+      "import": "./options-vue3.mjs",
+      "require": "./options-vue3.cjs.js",
+      "default": "./options-vue3.mjs"
+    },
     "./ssr": {
       "types": "./ssr.d.ts",
       "import": "./ssr.mjs",
@@ -32,6 +38,11 @@
       "types": "./composition.mjs.d.ts",
       "import": "./composition.mjs",
       "default": "./composition.mjs"
+    },
+    "./options-vue3.mjs": {
+      "types": "./options-vue3.mjs.d.ts",
+      "import": "./options-vue3.mjs",
+      "default": "./options-vue3.mjs"
     },
     "./ssr.mjs": {
       "types": "./ssr.mjs.d.ts",

--- a/tools/builder/packages.config.ts
+++ b/tools/builder/packages.config.ts
@@ -209,6 +209,12 @@ export default {
         require: './composition.cjs.js',
         default: './composition.mjs',
       },
+      './options-vue3': {
+        types: './options-vue3.d.ts',
+        import: './options-vue3.mjs',
+        require: './options-vue3.cjs.js',
+        default: './options-vue3.mjs',
+      },
       './ssr': {
         types: './ssr.d.ts',
         import: './ssr.mjs',
@@ -224,6 +230,11 @@ export default {
         types: './composition.mjs.d.ts',
         import: './composition.mjs',
         default: './composition.mjs',
+      },
+      './options-vue3.mjs': {
+        types: './options-vue3.mjs.d.ts',
+        import: './options-vue3.mjs',
+        default: './options-vue3.mjs',
       },
       './ssr.mjs': {
         types: './ssr.mjs.d.ts',

--- a/tools/builder/rollup.ts
+++ b/tools/builder/rollup.ts
@@ -350,6 +350,15 @@ export async function rollupEffectorVue() {
     }),
     createEsCjs(name, {
       file: {
+        cjs: dir(`npm/${name}/options-vue3.cjs.js`),
+        es: dir(`npm/${name}/options-vue3.mjs`),
+      },
+      input: 'options-vue3',
+      inputExtension: 'ts',
+      replaceVueReactivity: true,
+    }),
+    createEsCjs(name, {
+      file: {
         cjs: dir(`npm/${name}/ssr.cjs.js`),
         es: dir(`npm/${name}/ssr.mjs`),
       },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
       "forest": ["packages/forest/index.d.ts"],
       "effector-vue/ssr": ["packages/effector-vue/ssr.d.ts"],
       "effector-vue/composition": ["packages/effector-vue/composition.d.ts"],
+      "effector-vue/options-vue3": ["packages/effector-vue/options-vue3.d.ts"],
       "effector-vue": ["packages/effector-vue/index.d.ts"]
     }
   },


### PR DESCRIPTION
In this PR, the order of links in the Vue documentation has been changed, the documentation for the options api for vue 3 has been updated, links with low priority have been moved down, work has begun on exporting the options api for vue 3, this work needs to be completed and i need help)

### Conventions
- [x] Please check your messages [against the guidelines](https://cbea.ms/git-commit/) if not, perform [interactive rebase](https://thoughtbot.com/blog/git-interactive-rebase-squash-amend-rewriting-history)
- [x] [Link an issue](https://github.com/effector/effector/issues/1178) your pull request closes or relates
- [ ] Finish exporting option with types

