### PR TITLE
Add skipVoid to type of domain.createStore

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -402,6 +402,7 @@ export class Domain implements Unit<any> {
             write: (state: State) => SerializedState
             read: (json: SerializedState) => State
           }
+      skipVoid?: boolean
     },
   ): StoreWritable<State>
   sid: string | null


### PR DESCRIPTION
At present, it looks like the root `createStore` has `skipVoid` available, but `domain.createStore` warns/errors on undefined, but also doesn't list `skipVoid` amongst its possible config options. This PR adds that!