### PR TITLE
fix(forest): properly handle createStore in classList

### DIFF
--- a/packages/forest/index.d.ts
+++ b/packages/forest/index.d.ts
@@ -9,7 +9,7 @@ export type StylePropertyMap = Partial<
   }
 >
 export type ClassListMap = {[cssClass: string]: StoreOrData<boolean>}
-export type ClassListArray = Array<Store<string | null> | string>
+export type ClassListArray = Array<Store<string | null> | Store<string> | string>
 
 export type HandlerMap =
   | Partial<{[K in keyof HTMLElementEventMap]: EventCallable<HTMLElementEventMap[K]>}>

--- a/src/forest/__tests__/classList.test.ts
+++ b/src/forest/__tests__/classList.test.ts
@@ -156,6 +156,33 @@ it('supports setting dynamic array class', async () => {
       "
     `)
 })
+it('supports setting dynamic array class without restore', async () => {
+  const [s1, s2] = await exec(async () => {
+    const setClass = createEvent<string>()
+    const $class = createStore("example").on(setClass, (_, value) => value)
+    using(el, () => {
+      h('div', {
+        text: 'content',
+        attr: {class: 'foreign'},
+        classList: [$class],
+      })
+    })
+    await act()
+    await act(() => {
+      setClass('updated')
+    })
+  })
+  expect(s1).toMatchInlineSnapshot(`
+      "
+      <div class='foreign example'>content</div>
+      "
+    `)
+  expect(s2).toMatchInlineSnapshot(`
+      "
+      <div class='foreign updated'>content</div>
+      "
+    `)
+})
 it('supports setting dynamic object class without class property', async () => {
   const [s1, s2] = await exec(async () => {
     const setClass = createEvent<boolean>()
@@ -241,6 +268,36 @@ it('supports merging static classList h with spec', async () => {
   expect(s1).toMatchInlineSnapshot(`
       "
       <div class='second first'>content</div>
+      "
+    `)
+})
+
+it('supports setting dynamic array class with spec without restore', async () => {
+  const [s1, s2] = await exec(async () => {
+    const setClass = createEvent<string>()
+    const $class = createStore('example').on(setClass, (_, value) => value)
+    using(el, () => {
+      h('div', {
+        text: 'content',
+        attr: {class: 'foreign'},
+        fn() {
+          spec({classList: [$class]})
+        },
+      })
+    })
+    await act()
+    await act(() => {
+      setClass('updated')
+    })
+  })
+  expect(s1).toMatchInlineSnapshot(`
+      "
+      <div class='foreign example'>content</div>
+      "
+    `)
+  expect(s2).toMatchInlineSnapshot(`
+      "
+      <div class='foreign updated'>content</div>
       "
     `)
 })

--- a/src/forest/method/spec.ts
+++ b/src/forest/method/spec.ts
@@ -10,6 +10,8 @@ import type {
   ClassListProperty,
 } from '../index.h'
 
+import {createStore} from 'effector'
+
 import {escapeTag} from '../bindings'
 import {currentTemplate} from '../template'
 import {assertClosure} from '../assert'
@@ -112,16 +114,16 @@ function normalizeClassList(
 ) {
   if (Array.isArray(classList)) {
     classList.forEach(className => {
-      const name =
-        typeof className === 'string'
-          ? classListArray(className)
-          : className.map(optionalClass => classListArray(optionalClass || ''))
-      const enabled =
-        typeof className === 'string'
-          ? true
-          : className.map(optionalClass => optionalClass !== null)
-
-      cb({name, enabled})
+      if (typeof className === 'string') {
+        const name = classListArray(className)
+        const enabled = true
+        cb({name, enabled})
+      } else {
+        const name = createStore(classListArray(className.getState() ?? ''))
+          .on(className, (_, value) => value ? classListArray(value) : [])
+        const enabled = className.map(value => value !== null)
+        cb({name, enabled})
+      }
     })
   } else {
     forIn(classList, (enabled, names) => {


### PR DESCRIPTION
In forect, when creating the css class store with createStore directly — without additional call to restore — the initial value was not being applied correctly to the classList.

The fix creates a new store with the correct initial value to handle updates, ensuring the initial state is properly set and all the further updates to the class store is being applied.

Fixes #965

### Conventions
- [ ] Please check your messages [against the guidelines](https://cbea.ms/git-commit/) if not, perform [interactive rebase](https://thoughtbot.com/blog/git-interactive-rebase-squash-amend-rewriting-history)
- [ ] [Link an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) your pull request closes or relates
