### PR TITLE
docs: changelog for effector-vue 23.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ See also [separate changelogs for each library](https://changelog.effector.dev/)
 
 ## effector-vue 23.2.0
 
+- Fix nested reactivity in `useVModel` and `useGate` on Vue 3.5: the `deep` watch option shipped as `1` after minification, and Vue 3.5 reads a number as the depth to traverse ([issue #1344](https://github.com/effector/effector/issues/1344), [PR #1345](https://github.com/effector/effector/pull/1345), thanks [egoson](https://github.com/egoson) for the report)
+- Fix `useUnit(effect)` with a single effect: it returns a bound function, as the typings promise, instead of `{unit}` ([PR #1341](https://github.com/effector/effector/pull/1341))
+- Make the root `effector-vue` entry loadable on Vue 3 and export `EffectorScopePlugin` from `effector-vue/composition` ([issue #1280](https://github.com/effector/effector/issues/1280), [issue #1131](https://github.com/effector/effector/issues/1131), [PR #1343](https://github.com/effector/effector/pull/1343))
+- Fix the Vue 3 typings of `effector-vue/composition`: types come from `vue` instead of `@vue/reactivity`, and CI typechecks them ([issue #1186](https://github.com/effector/effector/issues/1186), [PR #1342](https://github.com/effector/effector/pull/1342))
+
 ## effector-vue 23.1.1
 
 - Fix `Date` suppport in `useVModel`, `createGate` and options API ([PR #1228](https://github.com/effector/effector/pull/1228), thanks [egoson](https://github.com/egoson))


### PR DESCRIPTION
### Conventions
- [x] Please check your messages [against the guidelines](https://cbea.ms/git-commit/) if not, perform [interactive rebase](https://thoughtbot.com/blog/git-interactive-rebase-squash-amend-rewriting-history)
- [x] [Link an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) your pull request closes or relates

Relates to #1340, #1347

Fills the empty `effector-vue 23.2.0` section with the four changes merged into `release/vue/23_2_0`: #1341, #1342, #1343, #1345. Text only, no code.
